### PR TITLE
configure.sh: change to directory before install

### DIFF
--- a/configure/configure.sh
+++ b/configure/configure.sh
@@ -27,6 +27,9 @@ fi
 if [ "$1" == "-install" ]
 then
     echo "installing"
+    
+    #move to unzipped directory
+    cd `dirname "$0"`
 
     #remove all xattrs
     /usr/bin/xattr -rc *


### PR DESCRIPTION
If we don’t and try to run the script from somewhere else, it fails:

```bash
installing
chown: rules.plist: No such file or directory
chmod: rules.plist: No such file or directory
cp: rules.plist: No such file or directory
chown: LuLu.kext: No such file or directory
cp: LuLu.kext: No such file or directory
/Library/Extensions/LuLu.kext failed to load - (libkern/kext) not found; check the system/kernel logs for errors or try kextutil(8).
kext installed and loaded
chown: LuluDaemon: No such file or directory
cp: LuluDaemon: No such file or directory
cp: com.objective-see.lulu.plist: No such file or directory
/Library/LaunchDaemons/com.objective-see.lulu.plist: No such file or directory
launch daemon installed and loaded
cp: LuLu.app: No such file or directory
```

After the script exists we’ll be left at the directory we were at, so no need to `cd` back.