### PR TITLE
Fixes for case-sensitive volumes

### DIFF
--- a/configure/configure.sh
+++ b/configure/configure.sh
@@ -50,10 +50,10 @@ then
     echo "kext installed and loaded"
 
     #install & load launch daemon
-    chown -R root:wheel LuluDaemon
+    chown -R root:wheel LuLuDaemon
     chown -R root:wheel com.objective-see.lulu.plist
 
-    mv LuluDaemon /Library/Objective-See/LuLu/
+    mv LuLuDaemon /Library/Objective-See/LuLu/
     mv com.objective-see.lulu.plist /Library/LaunchDaemons/
     launchctl load /Library/LaunchDaemons/com.objective-see.lulu.plist
 


### PR DESCRIPTION
Installation crashed with following stdout on my case-sensitive volume:
```
installing
kext installed and loaded
chown: LuluDaemon: No such file or directory
mv: rename LuluDaemon to /Library/Objective-See/LuLu/LuluDaemon: No such file or directory
launch daemon installed and loaded
install complete
```