### PR TITLE
fix a bug where the VirusTotal button was not properly disabled

### DIFF
--- a/shared/DaemonComms.m
+++ b/shared/DaemonComms.m
@@ -70,11 +70,11 @@
     }] getRules:wait4Change reply:^(NSDictionary* rules)
     {
          //respond with rules
-         dispatch_async(dispatch_get_main_queue(), ^
+         [[NSRunLoop mainRunLoop] performInModes:@[NSDefaultRunLoopMode, NSModalPanelRunLoopMode] block:^
          {
                 //respond
                 reply(rules);
-         });
+         }];
     }];
     
     return;


### PR DESCRIPTION
The block passed to -[DaemonComms getRules:reply:] in -[AlertWindowController setVTButtonState] is not executed while the modal alert window is showing.
This PR fixes the bug by executing the block in NSModalPanelRunLoopMode.
