### PR TITLE
add library validation flag for code signing

### DIFF
--- a/configure/configure.xcodeproj/project.pbxproj
+++ b/configure/configure.xcodeproj/project.pbxproj
@@ -510,6 +510,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CODE_SIGN_FLAGS = "-o library";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.objective-see.lulu.installer";
 				PRODUCT_NAME = "LuLu Installer";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/launchDaemon/launchDaemon.xcodeproj/project.pbxproj
+++ b/launchDaemon/launchDaemon.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 					"$(PROJECT_DIR)/../shared/libs",
 					"$(inherited)",
 				);
-				OTHER_CODE_SIGN_FLAGS = "-o hard,kill";
+				OTHER_CODE_SIGN_FLAGS = "-o hard,kill -o library";
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = LuLu;
 			};

--- a/loginItem/loginItem.xcodeproj/project.pbxproj
+++ b/loginItem/loginItem.xcodeproj/project.pbxproj
@@ -569,7 +569,7 @@
 				INFOPLIST_FILE = loginItem/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../shared/libs";
-				OTHER_CODE_SIGN_FLAGS = "-o hard,kill";
+				OTHER_CODE_SIGN_FLAGS = "-o hard,kill -o library";
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.objective-see.lulu.helper";
 				PRODUCT_NAME = "LuLu Helper";

--- a/mainApp/mainApp.xcodeproj/project.pbxproj
+++ b/mainApp/mainApp.xcodeproj/project.pbxproj
@@ -605,7 +605,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../Carthage/Build/Mac";
 				INFOPLIST_FILE = mainApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				OTHER_CODE_SIGN_FLAGS = "-o hard,kill";
+				OTHER_CODE_SIGN_FLAGS = "-o hard,kill -o library";
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.objective-see.lulu";
 				PRODUCT_NAME = LuLu;


### PR DESCRIPTION
https://developer.apple.com/library/content/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html#//apple_ref/doc/uid/TP40005929-CH4-SW9

Without the flag, evil code can be injected with DYLD_ variable to bypass XPC validation, which you've already discussed years ago.