### PR TITLE
Add ellipsis to menu items

### DIFF
--- a/mainApp/mainApp/AppDelegate.m
+++ b/mainApp/mainApp/AppDelegate.m
@@ -255,7 +255,7 @@ bail:
     if(nil == self.rulesWindowController)
     {
         //alloc
-        rulesWindowController = [[RulesWindowController alloc] initWithWindowNibName:@"Rules"];
+        rulesWindowController = [[RulesWindowController alloc] initWithWindowNibName:@"Rules..."];
     }
 
     //center
@@ -278,7 +278,7 @@ bail:
     if(nil == self.prefsWindowController)
     {
         //alloc
-        prefsWindowController = [[PrefsWindowController alloc] initWithWindowNibName:@"Preferences"];
+        prefsWindowController = [[PrefsWindowController alloc] initWithWindowNibName:@"Preferences..."];
     }
     
     //center


### PR DESCRIPTION
It is a common convention for menu items to have ellipsis to indicate further user interaction is needed.
In this case, both the Preferences and Rules actions open new windows.

According to [Apple's Human Interface Guidelines](https://developer.apple.com/macos/human-interface-guidelines/menus/menu-anatomy/):

> Use an ellipsis whenever choosing a menu item requires additional input from the user. The ellipsis character (…) means a dialog or separate window will open and prompt the user for more information or to make a choice.