### PR TITLE
Delete dead space and remove duplicate entries in copies to bundles

### DIFF
--- a/configure/Configure/ConfigureWindowController.m
+++ b/configure/Configure/ConfigureWindowController.m
@@ -345,7 +345,7 @@ bail:
 -(void)beginEvent:(NSInteger)event
 {
     //status msg frame
-    CGRect statusMsgFrame = {{0,0}, {0,0}};
+    CGRect statusMsgFrame;
     
     //grab exiting frame
     statusMsgFrame = self.statusMsg.frame;
@@ -393,7 +393,7 @@ bail:
 -(void)completeEvent:(BOOL)success event:(NSInteger)event
 {
     //status msg frame
-    CGRect statusMsgFrame = {{0,0}, {0,0}};
+    CGRect statusMsgFrame;
     
     //action
     NSString* action = nil;

--- a/configure/configure.xcodeproj/project.pbxproj
+++ b/configure/configure.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		CDA6E638203B6B7900C78F91 /* objectiveSeeLogo.png in Resources */ = {isa = PBXBuildFile; fileRef = CDA6E634203B6B7900C78F91 /* objectiveSeeLogo.png */; };
 		CDA6E639203B6F1000C78F91 /* logging.m in Sources */ = {isa = PBXBuildFile; fileRef = CD17D53820104DD700F798D7 /* logging.m */; };
 		CDAAC241202255580032F2E6 /* utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = CDAAC23F202255580032F2E6 /* utilities.m */; };
-		CDAAC242202257A10032F2E6 /* utilities.m in Resources */ = {isa = PBXBuildFile; fileRef = CDAAC23F202255580032F2E6 /* utilities.m */; };
 		CDAAC243202257D70032F2E6 /* utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = CDAAC23F202255580032F2E6 /* utilities.m */; };
 		CDAFF441203E971F00F27635 /* com.objective-see.lulu.plist in Resources */ = {isa = PBXBuildFile; fileRef = CDAFF43F203E971F00F27635 /* com.objective-see.lulu.plist */; };
 /* End PBXBuildFile section */
@@ -340,7 +339,6 @@
 			files = (
 				CDA6E636203B6B7900C78F91 /* objectiveSeeText.png in Resources */,
 				CDA6E635203B6B7900C78F91 /* luluText.png in Resources */,
-				CDAAC242202257A10032F2E6 /* utilities.m in Resources */,
 				CDA6E638203B6B7900C78F91 /* objectiveSeeLogo.png in Resources */,
 				CDA6E62D203B674C00C78F91 /* configure.sh in Resources */,
 				BF65C19111B985C0007C20AB /* MainMenu.xib in Resources */,

--- a/loginItem/loginItem.xcodeproj/project.pbxproj
+++ b/loginItem/loginItem.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		7D16D6951F64E43300DB3161 /* UpdateWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7D16D6911F64E43300DB3161 /* UpdateWindow.xib */; };
 		7D16D6961F64E43300DB3161 /* UpdateWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D16D6931F64E43300DB3161 /* UpdateWindowController.m */; };
 		7D3B75141F13354900568828 /* StatusBarMenu.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D3B74FD1F13354900568828 /* StatusBarMenu.m */; };
-		7D3B75151F13354900568828 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7D3B75011F13354900568828 /* MainMenu.xib */; };
 		7D3B751A1F13354900568828 /* statusIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 7D3B750B1F13354900568828 /* statusIcon.png */; };
 		7D3B751B1F13354900568828 /* statusIcon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7D3B750C1F13354900568828 /* statusIcon@2x.png */; };
 		7D3B75251F13357D00568828 /* logging.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D3B75231F13357D00568828 /* logging.m */; };
@@ -391,7 +390,6 @@
 				7D46FF121F60EBAE00FEB0F8 /* luluIcon.png in Resources */,
 				7D7755F01F02E05B00D0017D /* MainMenu.xib in Resources */,
 				7DD260031F2442BB00277EC4 /* unsigned.png in Resources */,
-				7D3B75151F13354900568828 /* MainMenu.xib in Resources */,
 				7DD260221F25621400277EC4 /* parentsIconOver.png in Resources */,
 				7DD25FF01F23B73C00277EC4 /* Assets.xcassets in Resources */,
 				CD223E3B20830AFF0049A76B /* statusIconWhite.png in Resources */,

--- a/mainApp/mainApp.xcodeproj/project.pbxproj
+++ b/mainApp/mainApp.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		7D564DD61F18441500B8AAD6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7D564DBF1F18441500B8AAD6 /* Assets.xcassets */; };
 		7D564DD91F18441500B8AAD6 /* RulesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D564DC21F18441500B8AAD6 /* RulesWindowController.m */; };
 		7D564DDA1F18441500B8AAD6 /* AboutWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D564DC31F18441500B8AAD6 /* AboutWindowController.m */; };
-		7D564DDB1F18441500B8AAD6 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7D564DC51F18441500B8AAD6 /* MainMenu.xib */; };
 		7D564DDC1F18441500B8AAD6 /* AboutWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7D564DC71F18441500B8AAD6 /* AboutWindow.xib */; };
 		7D564DDD1F18441500B8AAD6 /* Rules.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7D564DC91F18441500B8AAD6 /* Rules.xib */; };
 		7D564DDE1F18441500B8AAD6 /* RuleRowCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D564DCA1F18441500B8AAD6 /* RuleRowCell.m */; };
@@ -397,7 +396,6 @@
 				7D564DB61F18434F00B8AAD6 /* MainMenu.xib in Resources */,
 				7DD2BF4B1F1C389600B33214 /* allow.png in Resources */,
 				7D704AB71F6C83BF0067224E /* importRules.png in Resources */,
-				7D564DDB1F18441500B8AAD6 /* MainMenu.xib in Resources */,
 				7D564DEB1F1855E900B8AAD6 /* UpdateWindow.xib in Resources */,
 				CDA6E644203B9DA800C78F91 /* Welcome.xib in Resources */,
 				7DD2BF471F1C2B4200B33214 /* logoBG.png in Resources */,

--- a/shared/utilities.m
+++ b/shared/utilities.m
@@ -159,7 +159,7 @@ NSString* topLevelApp(NSString* binaryPath)
     NSString* appPath = nil;
     
     //offset of (first) '.app'
-    NSRange offset = {0,0};
+    NSRange offset;
     
     //find first instance of '.app' in path
     offset = [binaryPath rangeOfString:@".app/" options:NSCaseInsensitiveSearch];


### PR DESCRIPTION
Hi,

"statusMsgFrame" in ConfigureWindowController.m gets initialized later and there is no access to it before. So there is no need to allocate dead space. Same for "offset" in utilities.m.

Utilities.m is copied to the Resources folder in the installer bundle, which triggers a compiler action on copying. Removed this.

The MainMenu.xib is copied twice for installer and main app.