### PR TITLE
fixes the updating process bug related with #91

### DIFF
--- a/LuLu/App/Update.m
+++ b/LuLu/App/Update.m
@@ -91,7 +91,7 @@ extern os_log_t logHandle;
     }
     
     //extract latest version
-    latestVersion = productsVersionDictionary[PRODUCT_KEY][@"version"];
+    latestVersion = [productsVersionDictionary objectForKey:@"tag_name"];
     
     //dbg msg
     os_log_debug(logHandle, "latest version: %{public}@", latestVersion);

--- a/LuLu/Shared/consts.h
+++ b/LuLu/Shared/consts.h
@@ -71,7 +71,7 @@ enum Signer{None, Apple, AppStore, DevID, AdHoc};
 #define RULE_STATE_ALLOW 1
 
 //product version url
-#define PRODUCT_VERSIONS_URL @"https://objective-see.com/products.json"
+#define PRODUCT_VERSIONS_URL @"https://api.github.com/repos/objective-see/LuLu/releases/latest"
 
 //product key
 #define PRODUCT_KEY @"LuLu"


### PR DESCRIPTION
Fixes https://github.com/objective-see/LuLu/issues/91

The default updating URL depends on https://objective-see.com/products.json but it's no longer up-to-date in contrast with github. For this reason, I changed the updating url as github using github's public API. I also changed objectForKey methods according to new URL.

Here's the working example. In this example, I'm on 1.1.0 and program says 1.1.1 is available.

<img width="933" alt="screen shot 2018-10-19 at 00 49 02" src="https://user-images.githubusercontent.com/10091984/47186622-d3836380-d339-11e8-8d3e-1a6615ba0200.png">
