### PR TITLE
Add --cask flag to brew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ LuLu should build cleanly in Xcode (though you will have to remove code signing 
 **To Install:** \
 Simply run the installer application: `LuLu Installer.app`
 
-    brew install lulu
+    brew install --cask lulu
 
 **To Support:** \
 &#x2764;&nbsp; Love this product and want to support it? Please check out my [patreon page](https://www.patreon.com/objective_see) :)


### PR DESCRIPTION
When following the current installation instructions:
```console
Warning: 'lulu' formula is unreadable: No available formula with the name "lulu".
Warning: No available formula with the name "lulu".
Error: No similarly named formulae found.
Found a cask named "lulu" instead. Try
  brew install --cask lulu

==> Searching for similarly named formulae...
Installing lulu has failed!
```