### PR TITLE
Modified update mechanism to use GitHub public API

### DIFF
--- a/LuLu/App/Update.m
+++ b/LuLu/App/Update.m
@@ -91,7 +91,10 @@ extern os_log_t logHandle;
     }
     
     //extract latest version
-    latestVersion = productsVersionDictionary[PRODUCT_KEY][@"version"];
+    latestVersion = productsVersionDictionary[@"tag_name"];
+    
+    //remove any prefix 'v' from tag number
+    latestVersion = [latestVersion stringByReplacingOccurrencesOfString:@"v" withString:@""];
     
     //dbg msg
     os_log_debug(logHandle, "latest version: %{public}@", latestVersion);

--- a/LuLu/Shared/consts.h
+++ b/LuLu/Shared/consts.h
@@ -74,10 +74,7 @@ enum Signer{None, Apple, AppStore, DevID, AdHoc};
 #define RULE_STATE_ALLOW 1
 
 //product version url
-#define PRODUCT_VERSIONS_URL @"https://objective-see.com/products.json"
-
-//product key
-#define PRODUCT_KEY @"LuLu"
+#define PRODUCT_VERSIONS_URL @"https://api.github.com/repos/objective-see/LuLu/releases/latest"
 
 //product url
 #define PRODUCT_URL @"https://objective-see.com/products/lulu.html"


### PR DESCRIPTION
Modified update mechanism to use GitHub public API over the legacy products.json on ObjectiveSee domain.

This PR will supersede the stagnant API which has been open for nearly 3 years here: https://github.com/objective-see/LuLu/pull/99.

This should resolve the following issues:
* https://github.com/objective-see/LuLu/issues/91
* https://github.com/objective-see/LuLu/issues/302
* https://github.com/objective-see/LuLu/issues/314
* https://github.com/objective-see/LuLu/issues/389

There may be more but this is not an exhaustive list.

Unfortunately i have been unable to test this change due to issues with my development environment so it would be massively appreciated if this could be pulled down and tested by another volunteer or yourself @objective-see to confirm this works as intended.