### PR TITLE
capitalize brand name Apple and acronym MDM

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,21 @@ LuLu is supported by the "Friends of Objective-See" such as:
   <img src="https://objective-see.com/images/friends/jamf.png" height="50px" />
 </a>
 \
-...the standard in apple enterprise management.
+...the standard in Apple enterprise management.
 
 \
 <a href="http://mosyle.com/">
   <img src="https://objective-see.com/images/friends/mosyle.png" height="50px" />
 </a>
 \
-...modern apple mdm & security for enterprise &amp; education.
+...modern Apple MDM & security for enterprise &amp; education.
 
 \
 <a href="http://kandji.io/">
   <img src="https://objective-see.com/images/friends/kandji.png" height="50px" />
 </a>
 \
-...next-generation apple enterprise management.
+...next-generation Apple enterprise management.
 
 \
 <a href="https://1password.com/?utm_medium=parnter&utm_source=Objective-See&utm_campaign=gp&utm_content=sponsorship">


### PR DESCRIPTION
spotted what looked like a typographical error, and wanted to report it back