### PR TITLE
Refine German translation

### DIFF
--- a/LuLu/App/mul.lproj/AboutWindow.xcstrings
+++ b/LuLu/App/mul.lproj/AboutWindow.xcstrings
@@ -98,7 +98,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mehr Informationen"
+            "value" : "Weitere Informationen"
           }
         },
         "en" : {

--- a/LuLu/App/mul.lproj/AddRule.xcstrings
+++ b/LuLu/App/mul.lproj/AddRule.xcstrings
@@ -8,7 +8,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Externer Port"
+            "value" : "Remote Port"
           }
         },
         "en" : {
@@ -38,7 +38,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Externe address/domain"
+            "value" : "Remote Adresse/Domain"
           }
         },
         "en" : {
@@ -158,7 +158,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blockieren"
+            "value" : " Blockieren"
           }
         },
         "en" : {
@@ -218,7 +218,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erlauben"
+            "value" : " Erlauben"
           }
         },
         "en" : {

--- a/LuLu/App/mul.lproj/AlertWindow.xcstrings
+++ b/LuLu/App/mul.lproj/AlertWindow.xcstrings
@@ -8,7 +8,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "- Zertifizierungsinstanz 2"
+            "value" : " - Zertifizierungsinstanz 2"
           }
         },
         "en" : {
@@ -98,7 +98,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Regellänge:"
+            "value" : "Regeldauer:"
           }
         },
         "en" : {
@@ -248,7 +248,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Details"
+            "value" : "Details:"
           }
         },
         "en" : {
@@ -278,7 +278,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zertifizierungsinstanz"
+            "value" : "Zertifizierungsinstanzen:"
           }
         },
         "en" : {
@@ -338,7 +338,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "- Zertifizierungsinstanz 3"
+            "value" : " - Zertifizierungsinstanz 3"
           }
         },
         "en" : {
@@ -368,7 +368,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "(Umgekehrte) DNS: "
+            "value" : "(Reverse) DNS: "
           }
         },
         "en" : {
@@ -638,7 +638,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "- Zertifizierungsinstanz 1"
+            "value" : " - Zertifizierungsinstanz 1"
           }
         },
         "en" : {
@@ -668,7 +668,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "entfernter Endpunkt"
+            "value" : "Remote-Endpunkt"
           }
         },
         "en" : {
@@ -698,7 +698,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prozess"
+            "value" : "Prozess:"
           }
         },
         "en" : {
@@ -908,7 +908,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Uhrzeit:"
+            "value" : "Zeitstempel:"
           }
         },
         "en" : {

--- a/LuLu/App/mul.lproj/ItemPaths.xcstrings
+++ b/LuLu/App/mul.lproj/ItemPaths.xcstrings
@@ -38,7 +38,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Schliessen:"
+            "value" : "Schließen"
           }
         },
         "en" : {

--- a/LuLu/App/mul.lproj/Preferences.xcstrings
+++ b/LuLu/App/mul.lproj/Preferences.xcstrings
@@ -8,7 +8,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Jetzt überprüfen"
+            "value" : "Jetzt prüfen"
           }
         },
         "en" : {
@@ -98,7 +98,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bereit installierte Drittanbieterprogramme werden blockiert."
+            "value" : "Bereits installierte Drittanbieterprogramme werden erlaubt."
           }
         },
         "en" : {
@@ -128,7 +128,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hinweis: Wenn eine neue Verbindung hergestellt wird, ist manchmal nur die IP-Adresse verfügbar. In solchen Fällen können die Domains auf der Zulassungs- oder Sperrliste nicht abgeglichen werden, was sich darauf auswirken kann, ob eine Anfrage gesperrt oder zugelassen wird."
+            "value" : "Hinweis: Wenn eine neue Verbindung hergestellt wird, ist manchmal nur die IP-Adresse verfügbar. In solchen Fällen können die Domains in der Erlauben- oder Blockieren-Liste nicht abgeglichen werden, was sich darauf auswirken kann, ob eine Anfrage blockiert oder erlaubt wird."
           }
         },
         "en" : {
@@ -158,7 +158,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lokale oder externe Datei, die Endpunkte enthält, die immer zugelassen werden sollen."
+            "value" : "Lokale oder externe Datei, die Endpunkte enthält, die immer erlaubt werden sollen."
           }
         },
         "en" : {
@@ -308,7 +308,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Stille ausführen ohne Mitteilungen unter Anwendung bestehender Regeln."
+            "value" : "Stille Ausführung ohne Mitteilungen unter Anwendung bestehender Regeln."
           }
         },
         "en" : {
@@ -368,7 +368,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Programme in einem Simulator laufen, sind erlaubt."
+            "value" : "Programme, welche in einem Simulator laufen, werden erlaubt."
           }
         },
         "en" : {
@@ -398,7 +398,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blockierungs-Liste:"
+            "value" : "Blockieren-Liste:"
           }
         },
         "en" : {
@@ -428,7 +428,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LuLu-Einstellungen"
+            "value" : "LuLus Einstellungen"
           }
         },
         "en" : {
@@ -458,7 +458,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erlauben-Liste"
+            "value" : "Erlauben-Liste:"
           }
         },
         "en" : {
@@ -578,7 +578,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alle (UDP-)Verbindungen auf Port 53 sind erlaubt."
+            "value" : "Alle (UDP-)Verbindungen auf Port 53 werden erlaubt."
           }
         },
         "en" : {
@@ -608,7 +608,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nicht automatisch nach Aktualisierungen suchen."
+            "value" : "Nicht automatisch nach Updates suchen."
           }
         },
         "en" : {
@@ -788,7 +788,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Von Apple signierte Programme sind erlaubt."
+            "value" : "Von Apple signierte Programme werden erlaubt."
           }
         },
         "en" : {
@@ -848,7 +848,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktualiseren"
+            "value" : "Update"
           }
         },
         "en" : {
@@ -878,7 +878,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktualiseren"
+            "value" : "Update"
           }
         },
         "en" : {
@@ -968,7 +968,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alle über LuLu geleiteten Verbindungen werden blockiert (es sei denn, der Endpunkt ist ausdrücklich in der Liste „Erlauben“ aufgeführt)."
+            "value" : "Alle über LuLu geleiteten Verbindungen werden blockiert (es sei denn, der Endpunkt ist ausdrücklich in der „Erlauben“-Liste aufgeführt)."
           }
         },
         "en" : {
@@ -1088,7 +1088,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Simulator-Programme erlauben"
+            "value" : "Simulator-Anwendungen erlauben"
           }
         },
         "en" : {
@@ -1178,7 +1178,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktualisierungsprüfung deaktivieren"
+            "value" : "Update-Prüfungen deaktivieren"
           }
         },
         "en" : {

--- a/LuLu/App/mul.lproj/Rules.xcstrings
+++ b/LuLu/App/mul.lproj/Rules.xcstrings
@@ -188,7 +188,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LuLu Regeln"
+            "value" : "LuLu-Regeln"
           }
         },
         "en" : {
@@ -278,7 +278,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Regel"
+            "value" : " Regel"
           }
         },
         "en" : {
@@ -338,7 +338,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Objektdetails…"
+            "value" : "Objektdetails..."
           }
         },
         "en" : {
@@ -428,7 +428,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verbindungsinfos"
+            "value" : "Verbindungsinfo"
           }
         },
         "en" : {
@@ -458,7 +458,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Regeln (neu)laden"
+            "value" : "Regeln (neu)laden..."
           }
         },
         "en" : {
@@ -488,7 +488,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Regeln hinzufügen"
+            "value" : "Regel hinzufügen"
           }
         },
         "en" : {

--- a/LuLu/App/mul.lproj/StartupWindowController.xcstrings
+++ b/LuLu/App/mul.lproj/StartupWindowController.xcstrings
@@ -8,7 +8,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Startet jetzt…"
+            "value" : "Startet jetzt..."
           }
         },
         "en" : {

--- a/LuLu/App/mul.lproj/UpdateWindow.xcstrings
+++ b/LuLu/App/mul.lproj/UpdateWindow.xcstrings
@@ -8,7 +8,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LuLu-Aktualisierung"
+            "value" : "LuLu Update"
           }
         },
         "en" : {
@@ -38,7 +38,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktualisierung"
+            "value" : "Update"
           }
         },
         "en" : {

--- a/LuLu/App/mul.lproj/Welcome.xcstrings
+++ b/LuLu/App/mul.lproj/Welcome.xcstrings
@@ -8,7 +8,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diese Option erlaub allen bereits installierten Drittanbieterprogrammen auf das Netzwerk zugreifen, ohne eine Mitteilung auszulösen"
+            "value" : "Diese Option erlaub allen bereits installierten Drittanbieterprogrammen auf das Netzwerk zugreifen, ohne eine Mitteilung auszulösen."
           }
         },
         "en" : {
@@ -68,7 +68,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1. Auf der „Systemerweiterung blockiert“-Meldung: drücke „Systemeinstellungen öffnen“."
+            "value" : "1. Auf der „Systemerweiterung blockiert“-Meldung drücke: „Systemeinstellungen öffnen“."
           }
         },
         "en" : {
@@ -128,7 +128,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Es beobachtet die Netzwerkaktivität und warnt, wenn ein Programm zum ersten Mal versucht, eine ausgehende Verbindung herzustellen, so dass diese zugelassen oder abgelehnt werden kann."
+            "value" : "Überwacht die Netzwerkaktivität und warnt, wenn ein Programm zum ersten Mal versucht, eine ausgehende Verbindung herzustellen, sodass diese erlaubt oder blockiert werden kann."
           }
         },
         "en" : {
@@ -207,7 +207,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lulu ist eine frei quelloffene Firewall für macOS"
+            "value" : "Lulu ist eine freie quelloffene Firewall für macOS"
           }
         },
         "en" : {
@@ -297,7 +297,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "4. Klicke in der Meldung „Netzwerkinhalte filtern“ auf: „Erlauben“"
+            "value" : "4. Klicke in dem Hinweis „Netzwerkinhalte filtern“ auf: „Erlauben“"
           }
         },
         "en" : {
@@ -357,7 +357,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diese Option erlaubt allen von Apple signierten Programmen auf das Netzwerk  zugreifen, ohne eine Mitteilung auszulösen"
+            "value" : "Diese Option erlaubt allen von Apple signierten Programmen auf das Netzwerk zuzugreifen, ohne eine Mitteilung auszulösen."
           }
         },
         "en" : {
@@ -417,7 +417,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diese Option erlaubt alle (UDP-) Verbindungen über Port 53"
+            "value" : "Diese Option erlaubt alle (UDP-) Verbindungen auf Port 53."
           }
         },
         "en" : {
@@ -447,7 +447,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "DNS-Verbindungen erlauben"
+            "value" : " DNS-Verbindungen erlauben"
           }
         },
         "en" : {
@@ -597,7 +597,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nun konfigurieren wir LuLu:"
+            "value" : "Nun wollen wir LuLu konfigurieren:"
           }
         },
         "en" : {
@@ -627,7 +627,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bereits installierte Programme erlauben"
+            "value" : " Bereits installierte Anwendungen erlauben"
           }
         },
         "en" : {
@@ -687,7 +687,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple-Programme erlauben"
+            "value" : " Apple-Programme erlauben"
           }
         },
         "en" : {

--- a/LuLu/Shared/Localizable.xcstrings
+++ b/LuLu/Shared/Localizable.xcstrings
@@ -39,18 +39,16 @@
             "value" : "\r\nno encontrado en VirusTotal"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "non trovato su VirusTotal"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "non trouvé sur VirusTotal"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "non trovato su VirusTotal"
           }
         }
       }
@@ -70,18 +68,16 @@
             "value" : "\r\nRespuesta inválida recibida"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ricevuta risposta non valida"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Réponse invalide reçue"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricevuta risposta non valida"
           }
         }
       }
@@ -101,18 +97,16 @@
             "value" : "\r\nVer los de VirusTotal "
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vedi VirusTotal"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voir sur Virus Total"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vedi VirusTotal"
           }
         }
       }
@@ -132,18 +126,16 @@
             "value" : "tiene un problema de firma"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ha un problema con la firma"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "a un problème de signature"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ha un problema con la firma"
           }
         }
       }
@@ -163,18 +155,16 @@
             "value" : "no está firmado"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "non è firmato"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "n’est pas signé"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "non è firmato"
           }
         }
       }
@@ -194,18 +184,16 @@
             "value" : "no está válidamente firmado"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "non ha una firma valida"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "n’est pas valablement signé"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "non ha una firma valida"
           }
         }
       }
@@ -225,18 +213,16 @@
             "value" : "válidamente firmado"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ha una firma valida"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "est valablement signé"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ha una firma valida"
           }
         }
       }
@@ -256,18 +242,16 @@
             "value" : "firmado por un tercero/ad hoc"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "è firmato da "
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "signé par une tierce-partie/ad hoc"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "è firmato da "
           }
         }
       }
@@ -287,18 +271,16 @@
             "value" : "desconocido"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sconosciuto"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "inconnu"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sconosciuto"
           }
         }
       }
@@ -318,18 +300,16 @@
             "value" : "...por favor cópialo a /Aplicaciones y vuelve a abrirlo. "
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "…copia l’Applicazione in /Applications e riavviala"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "… merci de le copier vers /Applications et de relancer"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "…copia l’Applicazione in /Applications e riavviala"
           }
         }
       }
@@ -349,18 +329,16 @@
             "value" : "...esto eliminará completamente LuLu de tu Mac"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "…questo rimuoverà completamente LuLu dal tuo Mac"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "… ceci retirera Lulu complètement de votre Mac"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "…questo rimuoverà completamente LuLu dal tuo Mac"
           }
         }
       }
@@ -380,18 +358,16 @@
             "value" : "...esto terminará LuLu, hasta la próxima vez que inicies sesión."
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "…questo arresterà LuLu, fino al prossimo accesso"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "… ceci arrêtera Lulu, jusqu’à la prochaine connection."
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "…questo arresterà LuLu, fino al prossimo accesso"
           }
         }
       }
@@ -411,18 +387,16 @@
             "value" : "› no hay autoridades de firma"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "› non firmato"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "> pas d’autorité de signature"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "› non firmato"
           }
         }
       }
@@ -448,18 +422,16 @@
             "value" : "%1$@ (pid: %2$@)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (pid: %@)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ (pid : %2$@)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (pid: %@)"
           }
         }
       }
@@ -485,18 +457,16 @@
             "value" : "%1$@ (firmante: %2$@)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ (firmato da: %2$@)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ (signataire : %2$@)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (firmato da: %2$@)"
           }
         }
       }
@@ -516,18 +486,16 @@
             "value" : "%@ (firmante: Apple Mac OS App Store)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (firmato da: Apple Mac OS App Store)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ (signataire : Apple Mac OS App Store)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (firmato da: Apple Mac OS App Store)"
           }
         }
       }
@@ -547,18 +515,16 @@
             "value" : "%@ (firmante: Apple Original)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (firmato da: Apple Proper)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ (signataire : Apple)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (firmato da: Apple Proper)"
           }
         }
       }
@@ -578,18 +544,16 @@
             "value" : "%@ (firmante: no válido/no firmado)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (firmato da: Non Valido/Non Firmato)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ (signataire : invalide/non signé)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (firmato da: Non Valido/Non Firmato)"
           }
         }
       }
@@ -609,18 +573,16 @@
             "value" : "%@ no existe!"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ non esiste!"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ n'existe pas !"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ non esiste!"
           }
         }
       }
@@ -640,18 +602,16 @@
             "value" : "%@ es un proceso legítimo de macOS "
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ è un processo legittimo di macOS"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ est un processus macOS légitime"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ è un processo legittimo di macOS"
           }
         }
       }
@@ -671,18 +631,16 @@
             "value" : "%@ no es un número válido (de puerto)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ non è un numero (di porta) valido"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ n'est un numéro (de port) valide"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ non è un numero (di porta) valido"
           }
         }
       }
@@ -708,18 +666,16 @@
             "value" : "%1$@ no es una expresión regular válida\r\ndetalles: %2$@"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ non è un’espressione regolare valida\ndettagli: %@"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%#$@ n’est pas une expression régulière valide\ndetails : %2$@"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ non è un’espressione regolare valida\ndettagli: %@"
           }
         }
       }
@@ -739,18 +695,16 @@
             "value" : "%@ esta regla, puede impactar la funcionalidad legítima del sistema...¿continuar?"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ questa regola potrebbe impattare alcune funzionalità di sistema ...continuare?"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ cette règle, peut impacter le fonctionnement légitime du système ... continuer ?"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ questa regola potrebbe impattare alcune funzionalità di sistema ...continuare?"
           }
         }
       }
@@ -770,18 +724,16 @@
             "value" : "la información de firma de código de %@ ha cambiado"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La firma di %@ è cambiata"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Les informations de signature de %@ ont changé"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La firma di %@ è cambiata"
           }
         }
       }
@@ -801,18 +753,16 @@
             "value" : "→ Eliminar Regla"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancella Regola"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "→ Supprimer la règle"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella Regola"
           }
         }
       }
@@ -832,18 +782,16 @@
             "value" : "→ Eliminar regla(s)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancella Regola/e"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "→ Supprimer les règles"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella Regola/e"
           }
         }
       }
@@ -863,18 +811,16 @@
             "value" : "→ Editar Regla"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifica Regola"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "→ Éditer la règle"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica Regola"
           }
         }
       }
@@ -894,18 +840,16 @@
             "value" : "→ Mostrar ruta(s)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra percorso/i"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "→ Montrer le(s) chemin(s)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra percorso/i"
           }
         }
       }
@@ -948,18 +892,16 @@
             "value" : "2. En Configuración del Sistema, deslice hasta 'LuLu' y haga click en 'Permitir'"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. Nelle Impostazioni di Sistema, scorri fino alla voce “LuLu” e clicca su “Consenti”"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2. Dans Réglages Systèmes, descendez jusqu’à 'LuLu' et cliquez sur 'Approuver'"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. Nelle Impostazioni di Sistema, scorri fino alla voce “LuLu” e clicca su “Consenti”"
           }
         }
       }
@@ -979,18 +921,16 @@
             "value" : "2. En Configuración del Sistema, active la extensión de Lulu"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. Nelle Impostazioni di Sistema, abilita l’estensione LuLu"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2. Dans Réglages Systèmes, activer l’extension LuLu"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. Nelle Impostazioni di Sistema, abilita l’estensione LuLu"
           }
         }
       }
@@ -1010,18 +950,16 @@
             "value" : "¡una nueva versión (%@) está disponible!"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "una nuova versione (%@) è disponibile!"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "une nouvelle version (%@) est disponible !"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "una nuova versione (%@) è disponibile!"
           }
         }
       }
@@ -1064,18 +1002,16 @@
             "value" : "Agregado en las últimas 24 horas (ordenado por hora de creación)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiunte nelle ultime 24 ore (ordinate per data di creazione)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ajoutés ces dernières 24 heures (trié par date de création)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiunte nelle ultime 24 ore (ordinate per data di creazione)"
           }
         }
       }
@@ -1095,18 +1031,16 @@
             "value" : "Todas las Reglas"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tutte le Regole"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toute les règles"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutte le Regole"
           }
         }
       }
@@ -1126,18 +1060,16 @@
             "value" : "Permitir"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autoriser"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consenti"
           }
         }
       }
@@ -1157,18 +1089,16 @@
             "value" : "Permitir (pid: %@)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti (pid: %@)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autoriser (pid : %@)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consenti (pid: %@)"
           }
         }
       }
@@ -1188,18 +1118,16 @@
             "value" : "Permitir (hasta: %@)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti (fino a: %@)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Autoriser (jusqu’à : %@)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consenti (fino a: %@)"
           }
         }
       }
@@ -1219,18 +1147,16 @@
             "value" : "cualquier dirección"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ogni indirizzo"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "toute adresse"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ogni indirizzo"
           }
         }
       }
@@ -1250,18 +1176,16 @@
             "value" : "cualquier puerto"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ogni porta"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "tout port"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ogni porta"
           }
         }
       }
@@ -1281,18 +1205,16 @@
             "value" : "Cualquier programa"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ogni programma"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tout programme"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ogni programma"
           }
         }
       }
@@ -1335,18 +1257,16 @@
             "value" : "Bloquear"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blocca"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bloquer"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blocca"
           }
         }
       }
@@ -1366,18 +1286,16 @@
             "value" : "Bloquear (pid: %@)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blocca (pid: %@)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bloquer (pid : %@)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blocca (pid: %@)"
           }
         }
       }
@@ -1397,18 +1315,16 @@
             "value" : "Bloquear (hasta: %@)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blocca (fino a: %@)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bloquer (jusqu’à : %@)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blocca (fino a: %@)"
           }
         }
       }
@@ -1428,18 +1344,16 @@
             "value" : "Cancelar"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancella"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Annuler"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella"
           }
         }
       }
@@ -1459,18 +1373,16 @@
             "value" : "Se limpiaron %ld reglas"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%ld regole pulite"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%ld règles nettoyées"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%ld regole pulite"
           }
         }
       }
@@ -1513,18 +1425,16 @@
             "value" : "Continuar"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continua"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continuer"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua"
           }
         }
       }
@@ -1567,18 +1477,16 @@
             "value" : "Desactivado"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disabilita"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Désactiver"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disabilita"
           }
         }
       }
@@ -1598,18 +1506,16 @@
             "value" : "Activado"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abilita"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Activer"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abilita"
           }
         }
       }
@@ -1629,18 +1535,16 @@
             "value" : "ERROR: activación fallida"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRORE: Attivazione fallita"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERREUR: échec de l’activation"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERRORE: Attivazione fallita"
           }
         }
       }
@@ -1660,18 +1564,16 @@
             "value" : "ERROR: Fallo al limpiar las reglas"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRORE: Pulizia regole non completata"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERREUR : Échec du nettoyage des règles"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERRORE: Pulizia regole non completata"
           }
         }
       }
@@ -1691,18 +1593,16 @@
             "value" : "ERROR: Fallo al exportar las reglas"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRORE: Esportazione delle regole non completata"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERREUR : Échec de l'exportation des règles"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERRORE: Esportazione delle regole non completata"
           }
         }
       }
@@ -1722,18 +1622,16 @@
             "value" : "ERROR: Fallo al importar las reglas"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRORE: Importazione delle regole non completata"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERREUR : Échec de l'importation des règles"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERRORE: Importazione delle regole non completata"
           }
         }
       }
@@ -1753,18 +1651,16 @@
             "value" : "ERROR: fallo al cargar patrones"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRORE: Caricamento patrons non completato"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERREUR : échec du chargement des patrons"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERRORE: Caricamento patrons non completato"
           }
         }
       }
@@ -1784,18 +1680,16 @@
             "value" : "ERROR: ruta no válida"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRORE: Percorso non valido"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERREUR : Chemin invalide"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERRORE: Percorso non valido"
           }
         }
       }
@@ -1815,18 +1709,16 @@
             "value" : "ERROR: puerto no válido"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRORE: Porta non valida"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERREUR : port invalide"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERRORE: Porta non valida"
           }
         }
       }
@@ -1846,18 +1738,16 @@
             "value" : "ERROR: regex no válido"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRORE: Espressione regolare non corretta"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERREUR : regex invalide"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERRORE: Espressione regolare non corretta"
           }
         }
       }
@@ -1877,18 +1767,16 @@
             "value" : "error: falló la verificación de actualización"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "errore: impossibile controllare la disponibilità di aggiornamenti"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERREUR : échec du contrôle de la mise à jour"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "errore: impossibile controllare la disponibilità di aggiornamenti"
           }
         }
       }
@@ -1908,18 +1796,16 @@
             "value" : "Las extensiones deben ser aprobadas manualmente a través de las Preferencias del Sistema de Seguridad y Privacidad."
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le estensioni devono essere manualmente abilitate tramite il menù Sicurezza e Privacy delle Impostazioni di Sistema"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Les extensions doivent être approuvées manuellement via\nPréférences du système de sécurité et de confidentialité."
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le estensioni devono essere manualmente abilitate tramite il menù Sicurezza e Privacy delle Impostazioni di Sistema"
           }
         }
       }
@@ -1939,18 +1825,16 @@
             "value" : "Las extensiones deben ser aprobadas manualmente a través de las Preferencias del Sistema de Seguridad y Privacidad."
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le estensioni devono essere manualmente abilitate tramite il menù Sicurezza e Privacy delle Impostazioni di Sistema"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Les extensions doivent être approuvées manuellement via Sécurité et confidentialité Préférences du système."
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le estensioni devono essere manualmente abilitate tramite il menù Sicurezza e Privacy delle Impostazioni di Sistema"
           }
         }
       }
@@ -1970,18 +1854,16 @@
             "value" : "falló al activar la extensión de red"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile attivare l’estensione di rete"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "échec de l’activation de l’extension du réseau"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile attivare l’estensione di rete"
           }
         }
       }
@@ -2001,18 +1883,16 @@
             "value" : "falló al activar el filtro de red"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile attivare il filtro di rete"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "échec de l’activation du filtre réseau"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile attivare il filtro di rete"
           }
         }
       }
@@ -2032,18 +1912,16 @@
             "value" : "falló al activar la extensión del sistema"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile attivare l’estensione di sistema"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "échec de l’activation de l’extension système"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile attivare l’estensione di sistema"
           }
         }
       }
@@ -2063,18 +1941,16 @@
             "value" : "falló al activar la extensión del sistema/red"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile attivare l’estensione di sistema/rete"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "échec de l’activation de l’extension système/réseau"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile attivare l’estensione di sistema/rete"
           }
         }
       }
@@ -2094,18 +1970,16 @@
             "value" : "Falló al consultar con VirusTotal"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile contattare VirusTotal"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Échec de l’interrogation de VirusTotal"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile contattare VirusTotal"
           }
         }
       }
@@ -2148,18 +2022,16 @@
             "value" : "URL completo: %@"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URL Completo: %@"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "URL complète: %@"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL Completo: %@"
           }
         }
       }
@@ -2179,18 +2051,16 @@
             "value" : "Las Reglas Globales se aplican a todas las rutas"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le Regole Globali sono valide per tutti i percorsi"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Les Règles Globales s’appliquent à tous les chemins"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le Regole Globali sono valide per tutti i percorsi"
           }
         }
       }
@@ -2210,18 +2080,16 @@
             "value" : "Reglas %ld importadas"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%ld regole importate"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%ld règles importées"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%ld regole importate"
           }
         }
       }
@@ -2241,18 +2109,16 @@
             "value" : "La versión instalada (%@), es la más reciente."
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La versione installata (%@) è l’ultima disponibile"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "La version installée (%@), est la dernière"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La versione installata (%@) è l’ultima disponibile"
           }
         }
       }
@@ -2272,18 +2138,16 @@
             "value" : "se está conectando a %@"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "si sta connettendo a %@"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "se connecte à %@"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "si sta connettendo a %@"
           }
         }
       }
@@ -2326,18 +2190,16 @@
             "value" : "LuLu: desactivado"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LuLu: Disabilitato"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "LuLu : désactivé"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu: Disabilitato"
           }
         }
       }
@@ -2357,18 +2219,16 @@
             "value" : "LuLu: activado"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LuLu: Abilitato"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "LuLu : activé"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu: Abilitato"
           }
         }
       }
@@ -2388,18 +2248,16 @@
             "value" : "La Extensión de Red de LuLu no está en ejecución"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L’estensione di rete di LuLu non è attiva"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "L’extension réseau de LuLu ne fonctionne pas"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’estensione di rete di LuLu non è attiva"
           }
         }
       }
@@ -2419,18 +2277,16 @@
             "value" : "Más Información"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Più informazioni"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Plus d’infos"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Più informazioni"
           }
         }
       }
@@ -2496,18 +2352,16 @@
             "value" : "Sin embargo, ten en cuenta:\n▪ Las conexiones existentes no se verán afectadas.\n▪ El tráfico del sistema operativo (que no es ruteado a través de LuLu) no será bloqueado."
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tieni a mente:\n * Le connessioni esistente non verranno impattate.\n * Il traffico di rete del Sistema Operativo (che non passa tramite LuLu) non verrà bloccato."
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A noter cependant :\n▪ Les connexions existantes ne seront pas affectées.\n▪ Le trafic OS (non acheminé par LuLu) ne sera pas bloqué."
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tieni a mente:\n * Le connessioni esistente non verranno impattate.\n * Il traffico di rete del Sistema Operativo (che non passa tramite LuLu) non verrà bloccato."
           }
         }
       }
@@ -2527,15 +2381,13 @@
             "value" : "OK"
           }
         },
-
-        "it" : {
-            "stringUnit" : {
-              "state" : "translated",
-              "value" : "OK"
-            }
-        },
         "fr" : {
-
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
@@ -2558,18 +2410,16 @@
             "value" : "Versión antigua de LuLu instalada"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "È installata una vecchia versione di LuLu"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ancienne version de LuLu installée"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "È installata una vecchia versione di LuLu"
           }
         }
       }
@@ -2589,18 +2439,16 @@
             "value" : "Programas del Sistema Operativo (necesarios para la funcionalidad del sistema)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programmi del Sistema Operativo (Richiesti per le funzionalità di sistema)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Programmes du système d'exploitation (nécessaires au fonctionnement du système)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programmi del Sistema Operativo (Richiesti per le funzionalità di sistema)"
           }
         }
       }
@@ -2620,18 +2468,16 @@
             "value" : "Tráfico saliente será bloqueado ahora. "
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il traffico in uscita non verrà bloccato"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le trafic sortant est désormais bloqué."
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il traffico in uscita non verrà bloccato"
           }
         }
       }
@@ -2651,18 +2497,16 @@
             "value" : "Programas de terceros preinstalados (permitidos automáticamente y agregados aquí si está configurado 'permitir aplicaciones instaladas')"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Programmi di terze parti pre-installati (approvati automaticamente e mostrati qui se “Abilita applicazioni installate” è attivo)"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Programmes tiers préinstallés (automatiquement autorisés et ajoutés ici si l'option « autoriser les applications installées » est activée)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Programmi di terze parti pre-installati (approvati automaticamente e mostrati qui se “Abilita applicazioni installate” è attivo)"
           }
         }
       }
@@ -2682,18 +2526,16 @@
             "value" : "Argumentos Procesados: %@"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Argomenti del processo: %@"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Arguments de processus : %@"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Argomenti del processo: %@"
           }
         }
       }
@@ -2713,18 +2555,16 @@
             "value" : "Ruta del Proceso: %@"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Percorso del processo: %@"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chemin du processus : %@"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Percorso del processo: %@"
           }
         }
       }
@@ -2790,18 +2630,16 @@
             "value" : "Cerrar"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Termina"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quitter"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termina"
           }
         }
       }
@@ -2821,18 +2659,16 @@
             "value" : "Cerrar LuLu?"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminare LuLu?"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quitter LuLu ?"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminare LuLu?"
           }
         }
       }
@@ -2852,18 +2688,16 @@
             "value" : "Dominio Inverso: %@"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dominio inverso: %@"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Domaine inversé : %@"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dominio inverso: %@"
           }
         }
       }
@@ -2906,18 +2740,16 @@
             "value" : "Consulta el registro para más detalles"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vedi i log per altre informazioni"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voir le journal pour (plus) de détails"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vedi i log per altre informazioni"
           }
         }
       }
@@ -2937,18 +2769,16 @@
             "value" : "firmado por Apple oficialmente"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "firmato correttamente da Apple"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "signé par Apple"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "firmato correttamente da Apple"
           }
         }
       }
@@ -2968,18 +2798,16 @@
             "value" : "firmado por Mac App store"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "firmato da Mac App Store"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "signé par le Mac App Store"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "firmato da Mac App Store"
           }
         }
       }
@@ -2999,18 +2827,16 @@
             "value" : "firmado con un ID de Desarrollador de Apple"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "firmato da un Apple Developer ID"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "signé avec un Apple Developer ID"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "firmato da un Apple Developer ID"
           }
         }
       }
@@ -3030,18 +2856,16 @@
             "value" : "firmado, pero sin autorización de firma (¿adhoc?)"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "firmata da "
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "signé, mais pas d’autorité de signature (ad hoc ?)"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "firmata da "
           }
         }
       }
@@ -3061,18 +2885,16 @@
             "value" : "error de firma: %#lx"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "errore di firma: %#lx"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "erreur de signature : %#lx"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "errore di firma: %#lx"
           }
         }
       }
@@ -3092,18 +2914,16 @@
             "value" : "Esto debe desinstalarse antes de continuar. Haz click en 'Más información' para saber cómo desinstalarlo"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prima di continuare, il programma deve essere disinstallato. Clicca “Più informazioni” per scoprire come"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ceci doit être désinstallé avant de continuer. Cliquez sur « Plus d'informations » pour savoir comment le désinstaller."
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prima di continuare, il programma deve essere disinstallato. Clicca “Più informazioni” per scoprire come"
           }
         }
       }
@@ -3146,18 +2966,16 @@
             "value" : "Desinstalar"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disinstalla"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Désinstaller"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disinstalla"
           }
         }
       }
@@ -3177,18 +2995,16 @@
             "value" : "Desinstalar LuLu?"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disinstalla LuLu?"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Désinstaller LuLu ?"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disinstalla LuLu?"
           }
         }
       }
@@ -3208,18 +3024,16 @@
             "value" : "desconocido"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sconosciuto"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "inconnu"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sconosciuto"
           }
         }
       }
@@ -3239,18 +3053,16 @@
             "value" : "Actualizar"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiorna"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mise à jour"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiorna"
           }
         }
       }
@@ -3293,18 +3105,16 @@
             "value" : "Versión: %@"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione: %@"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Version : :@"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versione: %@"
           }
         }
       }
@@ -3324,18 +3134,16 @@
             "value" : "Esperando la aprobación de la Extensión de Red"
           }
         },
-
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In attesa di approvazione per l’estensione di rete"
- }
-        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "En attente de l'approbation de l'extension réseau"
-
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In attesa di approvazione per l’estensione di rete"
           }
         }
       }

--- a/LuLu/Shared/Localizable.xcstrings
+++ b/LuLu/Shared/Localizable.xcstrings
@@ -7,7 +7,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erkennungsrate:"
+            "value" : "\r\nErkennungsquote: "
           }
         },
         "es" : {
@@ -30,7 +30,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "nicht auf VirusTotal gefunden"
+            "value" : "\r\nnicht auf VirusTotal gefunden"
           }
         },
         "es" : {
@@ -59,7 +59,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ungültige Antwort erhalten"
+            "value" : "\r\nUngültige Antwort erhalten"
           }
         },
         "es" : {
@@ -88,7 +88,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "VirusTotal anschauen"
+            "value" : "\r\nAuf VirusTotal anzeigen:"
           }
         },
         "es" : {
@@ -117,7 +117,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "hat Signaturprobleme"
+            "value" : " hat ein Signaturproblem"
           }
         },
         "es" : {
@@ -146,7 +146,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ist nicht signiert"
+            "value" : " ist nicht signiert"
           }
         },
         "es" : {
@@ -175,7 +175,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ist nicht gültig signiert"
+            "value" : " ist nicht gültig signiert"
           }
         },
         "es" : {
@@ -204,7 +204,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ist gültig signiert"
+            "value" : " ist gültig signiert"
           }
         },
         "es" : {
@@ -233,7 +233,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "signiert von einem Drittanbieter/ad hoc-signiert"
+            "value" : " von Drittanbieter/ad hoc signiert"
           }
         },
         "es" : {
@@ -262,7 +262,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "unbekannt"
+            "value" : " unbekannt"
           }
         },
         "es" : {
@@ -291,7 +291,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "…bitte kopiere es nach /Applications und starte es neu."
+            "value" : "...bitte kopiere die Anwendung nach /Applications und starte sie neu."
           }
         },
         "es" : {
@@ -320,7 +320,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "…das wird LuLu vollständig von deinem Mac entfernen."
+            "value" : "...das wird LuLu vollständig von deinem Mac entfernen."
           }
         },
         "es" : {
@@ -349,7 +349,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "…das wird LuLu beenden, bis du dich das nächste mal einloggst."
+            "value" : "...das wird LuLu beenden, bis du dich das nächste Mal anmeldest."
           }
         },
         "es" : {
@@ -442,7 +442,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ (Signierer: %2$@)"
+            "value" : "%1$@ (Unterzeichner: %2$@)"
           }
         },
         "en" : {
@@ -477,7 +477,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ (Signierer: Apple Mac OS App Store)"
+            "value" : "%@ (Unterzeichner: Apple Mac OS App Store)"
           }
         },
         "es" : {
@@ -506,7 +506,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ (Signierer: Apple selbst)"
+            "value" : "%@ (Unterzeichner: Apple selbst)"
           }
         },
         "es" : {
@@ -535,7 +535,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ (Signierer: ungültig/unsigniert)"
+            "value" : "%@ (Unterzeichner: ungültig/unsigniert)"
           }
         },
         "es" : {
@@ -622,7 +622,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ ist keine gültiger Port"
+            "value" : "%@ ist keine gültige (Port-)Nummer"
           }
         },
         "es" : {
@@ -686,7 +686,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ diese Regel kann die legitime Systemfunktionalität beeinträchtigen ...fortfahren?"
+            "value" : "%@ diese Regel könnte die legitime Systemfunktionalität beeinträchtigen ...fortfahren?"
           }
         },
         "es" : {
@@ -715,7 +715,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die Codesignaturinformationen von %@ haben sich verändert."
+            "value" : "%@s Codesignierungsinformationen haben sich geändert."
           }
         },
         "es" : {
@@ -883,7 +883,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "2. Scrolle in den Systemeinstellungen zu der Stelle, an der „LuLu“ erwähnt wird, und klicke auf „Erlauben“."
+            "value" : "2. Scrolle in den Systemeinstellungen zu der Stelle, an der „LuLu“ erwähnt wird und klicke auf „Erlauben“."
           }
         },
         "es" : {
@@ -912,7 +912,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "2. Schalte in den Systemeinstellungen die LuLu-Erweiterung ein"
+            "value" : "2. Schalte die LuLu-Erweiterung in den Systemeinstellungen ein."
           }
         },
         "es" : {
@@ -993,7 +993,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "In den letzten 14 Stunden hinzugefügt (sortiert nach Erstellungszeit)"
+            "value" : "In den letzten 24 Stunden hinzugefügt (nach Erstellungszeit sortiert)"
           }
         },
         "es" : {
@@ -1225,7 +1225,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Programme (automatisch zugelassen und hier hinzugefügt, falls „Apple Programme erlauben“ aktiviert ist)"
+            "value" : "Apple-Programme (automatisch zugelassen und hier hinzugefügt, wenn „Apple-Programme erlauben“ aktiviert ist)"
           }
         },
         "es" : {
@@ -1364,7 +1364,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%ld Regeln gelöscht"
+            "value" : "%ld Regeln aufgeräumt"
           }
         },
         "es" : {
@@ -1445,7 +1445,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ordner-Regeln gelten für alle Objekte innerhalb eines Ordners"
+            "value" : "Verzeichnisregeln gelten für alle Objekte innerhalb des Verzeichnisses"
           }
         },
         "es" : {
@@ -1555,7 +1555,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "FEHLER: Regeln konnten nicht aufgeräumt werden"
+            "value" : "FEHLER: Aufräumen der Regeln fehlgeschlagen"
           }
         },
         "es" : {
@@ -1584,7 +1584,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "FEHLER: Regeln konnten nicht exportiert werden"
+            "value" : "FEHLER: Exportieren der Regeln fehlgeschlagen"
           }
         },
         "es" : {
@@ -1613,7 +1613,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "FEHLER: Regeln konnten nicht importiert werden"
+            "value" : "FEHLER: Importieren der Regeln fehlgeschlagen"
           }
         },
         "es" : {
@@ -1758,7 +1758,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fehler: Aktualisierungsprüfung fehlgeschlagen"
+            "value" : "Fehler: Prüfen auf Updates fehlgeschlagen"
           }
         },
         "es" : {
@@ -1787,7 +1787,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erweiterungen müssen manuell in den Systemeinstellungen unter Datenschutz & Sicherheit genehmigt werden."
+            "value" : "Erweiterungen müssen manuell in den Systemeinstellungen\r\nunter Datenschutz & Sicherheit genehmigt werden."
           }
         },
         "es" : {
@@ -1874,7 +1874,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "konnte nicht aktiviert werden"
+            "value" : "Netzwerkfilter konnte nicht aktiviert werden"
           }
         },
         "es" : {
@@ -1961,7 +1961,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abfrage von VirusTotal fehlgeschlagen"
+            "value" : "Abfrage bei VirusTotal fehlgeschlagen"
           }
         },
         "es" : {
@@ -1990,7 +1990,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Egebnisse"
+            "value" : "Funde"
           }
         },
         "es" : {
@@ -2013,7 +2013,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ganze URL: %@"
+            "value" : "Vollständige URL: %@"
           }
         },
         "es" : {
@@ -2042,7 +2042,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Allgemeine Regeln gelten für alle Pfade"
+            "value" : "Globale Regeln gelten für alle Pfade"
           }
         },
         "es" : {
@@ -2100,7 +2100,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die installierte Version (%@) ist die neuste."
+            "value" : "Die installierte Version (%@)\r\nist die neuste."
           }
         },
         "es" : {
@@ -2158,7 +2158,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LuLu muss von %@ ausgeführt werden."
+            "value" : "LuLu muss von diesem Pfad ausgeführt werden:\r\n  %@"
           }
         },
         "es" : {
@@ -2239,7 +2239,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LuLu's Netzwerkerweiterung läuft nicht"
+            "value" : "LuLus Netzwerkerweiterung läuft nicht"
           }
         },
         "es" : {
@@ -2401,7 +2401,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Veraltete LuLu-Version installiert"
+            "value" : "Veraltete Version von LuLu installiert"
           }
         },
         "es" : {
@@ -2459,7 +2459,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ausgehender Netzwerkverkehr wird jetzt blockiert"
+            "value" : "Ausgehender Datenverkehr wird jetzt blockiert."
           }
         },
         "es" : {
@@ -2488,7 +2488,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vorinstallierte Drittanbieterprogramme (automatisch zugelassen und hier hinzugefügt, falls “installierte Anwendungen zulassen“ aktiviert ist)"
+            "value" : "Vorinstallierte Drittanbieterprogramme (automatisch zugelassen und hier hinzugefügt, wenn „Bereits installierte Anwendungen erlauben“ aktiviert ist)"
           }
         },
         "es" : {
@@ -2517,7 +2517,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prozessargumente"
+            "value" : "Prozessargumente: %@"
           }
         },
         "es" : {
@@ -2546,7 +2546,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prozesspfad"
+            "value" : "Prozesspfad: %@"
           }
         },
         "es" : {
@@ -2679,7 +2679,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Umgekehrte Domain: %@"
+            "value" : "Reverse Domain: %@"
           }
         },
         "es" : {
@@ -2731,7 +2731,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Siehe Protokoll für (weitere) Details"
+            "value" : "Prüfe das Log für (weitere) Details"
           }
         },
         "es" : {
@@ -2847,7 +2847,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "signiert, aber keine Zertifizierungsinstanz (adhoc?)"
+            "value" : "signiert, aber keine Zertifizierungsinstanz (ad hoc?)"
           }
         },
         "es" : {
@@ -2905,7 +2905,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dies muss deinstalliert werden, bevor fortgefahren werden kann. Klicke auf „Weitere Informationen“, um zu erfahren, wie die Deinstallation geht."
+            "value" : "Dies muss zuerst deinstalliert werden.\r\nKlicke auf „Weitere Informationen“, um zu erfahren, wie du es deinstallieren kannst."
           }
         },
         "es" : {
@@ -2934,7 +2934,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Uhrzeit: %@"
+            "value" : "Zeitstempel: %@"
           }
         },
         "es" : {
@@ -3044,7 +3044,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktualisierung"
+            "value" : "Update"
           }
         },
         "es" : {
@@ -3073,7 +3073,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Benutzer-spezifischen Programm (manuell hinzugefügt, oder als Antwort auf eine Mitteilung)"
+            "value" : "Vom Benutzer festgelegte Programme (manuell hinzugefügt oder als Reaktion auf eine Mitteilung)"
           }
         },
         "es" : {


### PR DESCRIPTION
This pull request aims to further refine @Pixel-Master's already great German translation. I have added some missing control characters, indentation and variables, fixed a few typos and generally tried to standardize the terms (with special attention to technical terms and the terminology used in macOS).