### PR TITLE
Fixed German translation of VirusTotal option 

### DIFF
--- a/LuLu/App/mul.lproj/Preferences.xcstrings
+++ b/LuLu/App/mul.lproj/Preferences.xcstrings
@@ -1,4 +1,4 @@
-{
+LuLu/App/mul.lproj/Preferences.xcstrings{
   "sourceLanguage" : "en",
   "strings" : {
     "2qr-2x-A3U.title" : {
@@ -824,7 +824,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Neue Verbindungen sollten:"
+            "value" : "Neue Verbindungen:"
           }
         },
         "en" : {
@@ -1304,7 +1304,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blockiert"
+            "value" : "Blockieren"
           }
         },
         "en" : {
@@ -1928,7 +1928,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deaktivieren Sie die Integration mit VirusTotal."
+            "value" : "VirusTotal-Integration deaktivieren"
           }
         },
         "en" : {

--- a/LuLu/App/mul.lproj/Preferences.xcstrings
+++ b/LuLu/App/mul.lproj/Preferences.xcstrings
@@ -1,4 +1,4 @@
-LuLu/App/mul.lproj/Preferences.xcstrings{
+{
   "sourceLanguage" : "en",
   "strings" : {
     "2qr-2x-A3U.title" : {


### PR DESCRIPTION
Fixed German translation of VirusTotal option and made the first preferences option more fitting into the UI.

Also I noticed that some labels and buttons in the preferences are too short and cut of the string.