### PR TITLE
Add Urdu localization strings to LuLu app interface elements

### DIFF
--- a/LuLu/App/InfoPlist.xcstrings
+++ b/LuLu/App/InfoPlist.xcstrings
@@ -41,6 +41,12 @@
             "value" : "LuLu"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -93,6 +99,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Telif hakkı © 2020 Objective-See. Tüm hakları saklıdır."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کاپی رائٹ (c) 2020 Objective-See۔ تمام حقوق محفوظ ہیں۔"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/AboutWindow.xcstrings
+++ b/LuLu/App/mul.lproj/AboutWindow.xcstrings
@@ -59,6 +59,12 @@
             "value" : "Підтримайте нас!"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ہماری حمایت کریں!"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,6 +135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Версія:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورژن:"
           }
         },
         "zh-Hans" : {
@@ -203,6 +215,12 @@
             "value" : "Патрони і друзі"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سرپرست اور دوست"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -273,6 +291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Більше інформації"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مزید معلومات"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/AddRule.xcstrings
+++ b/LuLu/App/mul.lproj/AddRule.xcstrings
@@ -59,6 +59,12 @@
             "value" : "Віддалений порт"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ریموٹ پورٹ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,6 +135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Віддалена адреса/домен"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ریموٹ ایڈریس/ڈومین"
           }
         },
         "zh-Hans" : {
@@ -203,6 +215,12 @@
             "value" : "Додати правило (для вихідних з'єднань)"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قانون شامل کریں (باہر جانے والے کنکشنز کے لیے)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -273,6 +291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "regex?"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ریگولر ایکسپریشن؟"
           }
         },
         "zh-Hans" : {
@@ -347,6 +371,12 @@
             "value" : "Скасувати"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منسوخ کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -419,6 +449,12 @@
             "value" : "Блокувати"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلاک کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -486,6 +522,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "*"
+          }
+        },
+        "ur" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "*"
@@ -563,6 +605,12 @@
             "value" : "Дозволити"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اجازت دیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -635,6 +683,12 @@
             "value" : "Огляд"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تلاش کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -702,6 +756,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "*"
+          }
+        },
+        "ur" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "*"
@@ -779,6 +839,12 @@
             "value" : "Шлях до програми"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پروگرام پاتھ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -849,6 +915,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додати"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اضافہ کریں"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/AlertWindow.xcstrings
+++ b/LuLu/App/mul.lproj/AlertWindow.xcstrings
@@ -46,6 +46,12 @@
             "state" : "needs_review",
             "value" : "- imzalama otoritesi 2"
           }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " - سرٹیفیکیشن اتھارٹی 2"
+          }
         }
       },
       "shouldTranslate" : false
@@ -106,6 +112,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "З'єднання:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کنکشن:"
           }
         },
         "zh-Hans" : {
@@ -180,6 +192,12 @@
             "value" : "Тривалість правила:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قانون کی مدت:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -250,6 +268,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "порт/протокол:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پورٹ/پروٹوکول:"
           }
         },
         "zh-Hans" : {
@@ -324,6 +348,12 @@
             "value" : "Тривалість життя процесу"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عمل کی مدت"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -394,6 +424,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ГГ:хх"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HH:mm"
           }
         },
         "zh-Hans" : {
@@ -468,6 +504,12 @@
             "value" : "Деталі:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تفصیلات:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -538,6 +580,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Довірені підписанти:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سرٹیفیکیشن اتھارٹیز:"
           }
         },
         "zh-Hans" : {
@@ -612,6 +660,12 @@
             "value" : "Сповіщення LuLu"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu الارٹ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -670,6 +724,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "- imzalama otoritesi 3"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " - سرٹیفیکیشن اتھارٹی 3"
           }
         }
       },
@@ -731,6 +791,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "(зворотний) DNS:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(ریورس) ڈی این ایس:"
           }
         },
         "zh-Hans" : {
@@ -805,6 +871,12 @@
             "value" : "Деталі та параметри"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تفصیلات اور آپشنز"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -875,6 +947,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Межі правила:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قانون کا دائرہ کار:"
           }
         },
         "zh-Hans" : {
@@ -949,6 +1027,12 @@
             "value" : "шлях:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پاتھ:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1019,6 +1103,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PID:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پی آئی ڈی:"
           }
         },
         "zh-Hans" : {
@@ -1093,6 +1183,12 @@
             "value" : "Процес"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عمل"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1163,6 +1259,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Назва процесу"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عمل کا نام"
           }
         },
         "zh-Hans" : {
@@ -1237,6 +1339,12 @@
             "value" : "Назва"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نام"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1295,6 +1403,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "- imzalama otoritesi 1"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " - سرٹیفیکیشن اتھارٹی 1"
           }
         }
       },
@@ -1356,6 +1470,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Віддалена веб- або IP-адреса"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ریموٹ اینڈ پوائنٹ"
           }
         },
         "zh-Hans" : {
@@ -1430,6 +1550,12 @@
             "value" : "Процес:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عمل:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1500,6 +1626,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "повідомлення"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پیغام"
           }
         },
         "zh-Hans" : {
@@ -1574,6 +1706,12 @@
             "value" : "аргументи:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ارجومنٹس:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1644,6 +1782,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Завжди"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ہمیشہ"
           }
         },
         "zh-Hans" : {
@@ -1718,6 +1862,12 @@
             "value" : "IP-адреса"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آئی پی پتہ:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1788,6 +1938,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Блокувати"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلاک کریں"
           }
         },
         "zh-Hans" : {
@@ -1862,6 +2018,12 @@
             "value" : "Дійсне до:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تک:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1934,6 +2096,12 @@
             "value" : "Мітка часу:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ٹائم اسٹیمپ:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2004,6 +2172,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дозволити"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اجازت دیں"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/ItemPaths.xcstrings
+++ b/LuLu/App/mul.lproj/ItemPaths.xcstrings
@@ -59,6 +59,12 @@
             "value" : "Шлях(и):"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "راستہ/راستے:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,6 +135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрити"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بند کریں"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/MainMenu.xcstrings
+++ b/LuLu/App/mul.lproj/MainMenu.xcstrings
@@ -59,6 +59,12 @@
             "value" : "Показати…"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "دکھائیں..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,6 +135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Параметри…"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ترتیبات..."
           }
         },
         "zh-Hans" : {
@@ -203,6 +215,12 @@
             "value" : "Імпортувати…"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "درآمد کریں..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -273,6 +291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LuLu"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو"
           }
         },
         "zh-Hans" : {
@@ -347,6 +371,12 @@
             "value" : "Експортувати…"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "برآمد کریں..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -417,6 +447,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрити LuLu"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو کو ختم کریں"
           }
         },
         "zh-Hans" : {
@@ -491,6 +527,12 @@
             "value" : "Додати…"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اضافی کریں..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -561,6 +603,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LuLu"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو"
           }
         },
         "zh-Hans" : {
@@ -635,6 +683,12 @@
             "value" : "Видалити LuLu"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو ان انسٹال کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -705,6 +759,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Очистити"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "صاف کریں"
           }
         },
         "zh-Hans" : {
@@ -779,6 +839,12 @@
             "value" : "Вимкнути"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ناکارہ کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -849,6 +915,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Про LuLu"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو کے بارے میں"
           }
         },
         "zh-Hans" : {
@@ -923,6 +995,12 @@
             "value" : "Закрити LuLu"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو کو ختم کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -993,6 +1071,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Головне меню"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مینیو"
           }
         },
         "zh-Hans" : {
@@ -1067,6 +1151,12 @@
             "value" : "Правила"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قوانین"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1137,6 +1227,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Правила"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قوانین"
           }
         },
         "zh-Hans" : {
@@ -1211,6 +1307,12 @@
             "value" : "Монітор мережі.."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نیٹ ورک مانیٹر..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1281,6 +1383,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LuLu: увімкнено"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو: فعال"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/Preferences.xcstrings
+++ b/LuLu/App/mul.lproj/Preferences.xcstrings
@@ -59,6 +59,12 @@
             "value" : "Перевірити"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ابھی چیک کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,6 +135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Режим блокування"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلاک موڈ"
           }
         },
         "zh-Hans" : {
@@ -203,6 +215,12 @@
             "value" : "Створювати правила для нових з'єднань?"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نئے کنکشنز کے لیے قواعد بنائے جائیں؟"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -273,6 +291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Раніше встановлені сторонні програми будуть дозволені."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پہلے سے انسٹال شدہ، تیسرے فریق کے پروگراموں کو اجازت دی جائے گی۔"
           }
         },
         "zh-Hans" : {
@@ -347,6 +371,12 @@
             "value" : "Примітка: Коли встановлюється нове з'єднання, іноді доступна лише IP-адреса. У таких випадках не можна зіставити домени зі списком дозволених або заблокованих, що може вплинути на те, чи буде запит заблоковано або дозволено."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوٹ: جب ایک نیا کنکشن بنایا جاتا ہے، تو بعض اوقات صرف IP ایڈریس دستیاب ہوتا ہے۔ ایسے معاملات میں، اجازت یا بلاک لسٹ پر موجود ڈومینز کا مقابلہ نہیں کیا جا سکتا، جس سے یہ متاثر ہو سکتا ہے کہ درخواست بلاک کی جائے گی یا اجازت دی جائے گی۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -417,6 +447,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файл, що містить веб- або IP-адреси, які завжди дозволено."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مقامی یا ریموٹ فائل، جس میں ہمیشہ اجازت دینے والے اینڈ پوائنٹس شامل ہیں۔"
           }
         },
         "zh-Hans" : {
@@ -491,6 +527,12 @@
             "value" : "Файл, що містить веб- або IP-адреси, які завжди блокуються."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مقامی یا ریموٹ فائل، جس میں ہمیشہ بلاک کرنے والے اینڈ پوائنٹس شامل ہیں۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -561,6 +603,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Запускати без зображення іконки в панелі меню."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اسٹیٹس مینو بار میں آئیکن کو ظاہر کیے بغیر چلائیں۔"
           }
         },
         "zh-Hans" : {
@@ -635,6 +683,12 @@
             "value" : "Переглянути правила"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قواعد دیکھیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -705,6 +759,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дозволено"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اجازت دی گئی"
           }
         },
         "zh-Hans" : {
@@ -779,6 +839,12 @@
             "value" : "Запускати у фоновому режимі без сповіщень і застосовувати наявні правила."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرٹس کے بغیر خاموشی سے چلائیں اور موجودہ قواعد کو لاگو کریں۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -849,6 +915,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Так"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ہاں"
           }
         },
         "zh-Hans" : {
@@ -923,6 +995,12 @@
             "value" : "Програми, що працюють у середовищі Симулятора, будуть дозволені."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سیمولیٹر کے اندر چلنے والی ایپلیکیشنز کو اجازت دی جائے گی۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -993,6 +1071,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Список заблокованих:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلاک لسٹ:"
           }
         },
         "zh-Hans" : {
@@ -1067,6 +1151,12 @@
             "value" : "Параметри LuLu:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو کی ترتیبات"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1137,6 +1227,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Список дозволених:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اجازت دی گئی لسٹ:"
           }
         },
         "zh-Hans" : {
@@ -1211,6 +1307,12 @@
             "value" : "Переглянути"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "براؤز کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1281,6 +1383,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нові з'єднання мають бути:"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نئی کنکشنز کو ہونا چاہیے:"
           }
         },
         "zh-Hans" : {
@@ -1355,6 +1463,12 @@
             "value" : "Режим без іконки"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آئیکن کے بغیر موڈ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1425,6 +1539,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Увесь (UDP) трафік на порту 53 буде дозволено."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پورٹ 53 پر تمام (UDP) ٹریفک کو اجازت دی جائے گی۔"
           }
         },
         "zh-Hans" : {
@@ -1499,6 +1619,12 @@
             "value" : "Не перевіряти наявність нових версій автоматично."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نئی ورژنز کے لیے خودکار طور پر چیک نہ کریں۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1569,6 +1695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пасивний режим"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پسیو موڈ"
           }
         },
         "zh-Hans" : {
@@ -1643,6 +1775,12 @@
             "value" : "Дозволити установлені програми"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انسٹال شدہ پروگراموں کو اجازت دیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1713,6 +1851,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ні"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نہیں"
           }
         },
         "zh-Hans" : {
@@ -1787,6 +1931,12 @@
             "value" : "Режим"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "موڈ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1857,6 +2007,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Режим"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "موڈ"
           }
         },
         "zh-Hans" : {
@@ -1931,6 +2087,12 @@
             "value" : "Бінарні файли, підписані Apple, будуть дозволені."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپل کے دستخط شدہ بائنریز کو اجازت دی جائے گی۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2001,6 +2163,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Заблоковано"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلاک"
           }
         },
         "zh-Hans" : {
@@ -2075,6 +2243,12 @@
             "value" : "Оновити"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اپڈیٹ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2145,6 +2319,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Оновити"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اپڈیٹ"
           }
         },
         "zh-Hans" : {
@@ -2219,6 +2399,12 @@
             "value" : "Списки"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فہرستیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2289,6 +2475,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Списки"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فہرستیں"
           }
         },
         "zh-Hans" : {
@@ -2363,6 +2555,12 @@
             "value" : "Увесь трафік, що проходить через LuLu, буде заблоковано (якщо веб- або IP-адреса не в списку «Дозволених»)."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو کے ذریعے روٹ کیا گیا تمام ٹریفک بلاک کر دیا جائے گا (جب تک کہ اینڈ پوائنٹ واضح طور پر 'اجازت' کی فہرست میں نہ ہو)۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2433,6 +2631,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дозволити програми Apple"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپل پروگراموں کو اجازت دیں"
           }
         },
         "zh-Hans" : {
@@ -2507,6 +2711,12 @@
             "value" : "Правила"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قواعد"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2577,6 +2787,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Правила"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قواعد"
           }
         },
         "zh-Hans" : {
@@ -2651,6 +2867,12 @@
             "value" : "Дозволити програми Симулятора"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سیمولیٹر ایپلیکیشنز کو اجازت دیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2721,6 +2943,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Переглянути"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "براؤز کریں"
           }
         },
         "zh-Hans" : {
@@ -2795,6 +3023,12 @@
             "value" : "Дозволити DNS трафік"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DNS ٹریفک کو اجازت دیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2865,6 +3099,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Режим без VirusTotal"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وائرس ٹوٹل موڈ نہیں"
           }
         },
         "zh-Hans" : {
@@ -2939,6 +3179,12 @@
             "value" : "Вимкнути інтеграцію з VirusTotal."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وائرس ٹوٹل کے ساتھ انضمام کو غیر فعال کریں۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3009,6 +3255,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вимкнути перевірку оновлень"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اپڈیٹ چیکس کو غیر فعال کریں"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/Rules.xcstrings
+++ b/LuLu/App/mul.lproj/Rules.xcstrings
@@ -59,6 +59,12 @@
             "value" : "Мітка"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لیبل"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,6 +135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Назва елемента"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آئٹم کا نام"
           }
         },
         "zh-Hans" : {
@@ -203,6 +215,12 @@
             "value" : "Нещодавні правила"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حالیہ قوانین"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -273,6 +291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Текстове поле"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ٹیکسٹ سیل"
           }
         },
         "zh-Hans" : {
@@ -347,6 +371,12 @@
             "value" : "Користувацькі правила"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "صارف کے قوانین"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -417,6 +447,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Правила фільтрації"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قوانین فلٹر کریں"
           }
         },
         "zh-Hans" : {
@@ -491,6 +527,12 @@
             "value" : "Правила LuLu"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو قوانین"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -561,6 +603,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кастомний вигляд"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کاسٹم ویو"
           }
         },
         "zh-Hans" : {
@@ -635,6 +683,12 @@
             "value" : "Кастомний вигляд"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کاسٹم ویو"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -705,6 +759,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Правило"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قاعدہ"
           }
         },
         "zh-Hans" : {
@@ -779,6 +839,12 @@
             "value" : "Усі правила"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تمام قوانین"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -849,6 +915,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "деталі елемента…"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آئٹم کی تفصیلات..."
           }
         },
         "zh-Hans" : {
@@ -923,6 +995,12 @@
             "value" : "Правила Apple"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپل قوانین"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -993,6 +1071,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Стандартні правила"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ڈیفالٹ قوانین"
           }
         },
         "zh-Hans" : {
@@ -1067,6 +1151,12 @@
             "value" : "інформація про зʼєднання"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کنیکشن کا معلومات"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1137,6 +1227,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "(пере)завантаження правил..."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(ری) لوڈنگ قوانین..."
           }
         },
         "zh-Hans" : {
@@ -1211,6 +1307,12 @@
             "value" : "Додати правило"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قاعدہ شامل کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1281,6 +1383,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Правила від сторонніх постачальників"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تھرڈ پارٹی قوانین"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/StartupWindowController.xcstrings
+++ b/LuLu/App/mul.lproj/StartupWindowController.xcstrings
@@ -59,6 +59,12 @@
             "value" : "Запуск…"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اب شروع ہو رہا ہے..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -135,6 +141,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Примітка: LuLu найкраще працює на macOS 15.3+, оскільки Apple виправила помилки, що впливали на стабільність мережі."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نوٹ: لولو macOS 15.3+ پر بہترین کام کرتا ہے، کیونکہ ایپل نے نیٹ ورک کی استحکام کو متاثر کرنے والے بگز کو ٹھیک کیا ہے۔"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/StatusBarPopover.xcstrings
+++ b/LuLu/App/mul.lproj/StatusBarPopover.xcstrings
@@ -59,6 +59,12 @@
             "value" : "⌃"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌃"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -123,6 +129,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LuLu запущено і працює!"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "!لولو چل رہا ہے"
           }
         },
         "zh-Hans" : {
@@ -195,6 +207,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отримуйте доступ до нього звідси в будь-який час."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کسی بھی وقت یہاں سے اس تک رسائی حاصل کریں۔"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/UpdateWindow.xcstrings
+++ b/LuLu/App/mul.lproj/UpdateWindow.xcstrings
@@ -59,6 +59,12 @@
             "value" : "Оновлення LuLu"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو اپڈیٹ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,6 +135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Оновити"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اپڈیٹ"
           }
         },
         "zh-Hans" : {

--- a/LuLu/App/mul.lproj/Welcome.xcstrings
+++ b/LuLu/App/mul.lproj/Welcome.xcstrings
@@ -59,6 +59,12 @@
             "value" : "Ця опція дозволить будь-якому сторонньому додатку, який уже встановлено, отримувати доступ до мережі без сповіщення."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ آپشن کسی بھی پہلے سے انسٹال شدہ تھرڈ پارٹی ایپ کو الرٹ پیدا کیے بغیر نیٹ ورک تک رسائی کی اجازت دے گا۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,6 +135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дякуємо «Friends Objective-See»"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"Objective-See دوستوں\" کو شکریہ"
           }
         },
         "zh-Hans" : {
@@ -203,6 +215,12 @@
             "value" : "1. У сповіщенні «Системне розширення заблоковано» натисніть «Відкрити системні параметри»."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. \"سسٹم ایکسٹینشن بلاک\" الرٹ میں، کلک کریں: \"سسٹم سیٹنگز کھولیں\""
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -275,6 +293,12 @@
             "value" : "Спочатку, надайте доступ розширенню LuLu:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پہلے، LuLu نیٹ ورک ایکسٹینشن کو اجازت دیں:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -345,6 +369,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вона відстежує мережеву активність і сповіщає вас, коли програма вперше намагається ініціювати вихідне з'єднання, тож ви зможете його дозволити або заборонити."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ نیٹ ورک کی سرگرمیوں کو مانیٹر کرتا ہے اور آپ کو الرٹ کرتا ہے جب کوئی پروگرام پہلی بار باہر کی طرف کنیکشن قائم کرنے کی کوشش کرتا ہے، آپ کو اجازت دینے یا انکار کرنے کی اجازت دیتا ہے۔"
           }
         },
         "zh-Hans" : {
@@ -438,6 +468,12 @@
             "value" : "LuLu"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -508,6 +544,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LuLu — це безкоштовний фаєрвол із відкритим кодом для macOS."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu ایک مفت اوپن سورس فائر وال ہے جو macOS کے لیے ہے۔"
           }
         },
         "zh-Hans" : {
@@ -582,6 +624,12 @@
             "value" : "Ні"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نہیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -652,6 +700,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Підтримати LuLu?"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کیا آپ LuLu کی مدد کرنا چاہتے ہیں؟"
           }
         },
         "zh-Hans" : {
@@ -726,6 +780,12 @@
             "value" : "4. У сповіщенні «Фільтрувати мережевий контент» натисніть «Дозволити»."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. \"نیٹ ورک مواد کو فلٹر کریں\" الرٹ میں، کلک کریں: \"اجازت دیں\""
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -796,6 +856,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ласкаво просимо до"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خوش آمدید"
           }
         },
         "zh-Hans" : {
@@ -870,6 +936,12 @@
             "value" : "Ця опція дозволить будь-якому бінарному файлу, підписаному Apple, отримувати доступ до мережі без сповіщення."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ آپشن کسی بھی ایپل سائنڈ بائنری کو الرٹ پیدا کیے بغیر نیٹ ورک تک رسائی کی اجازت دے گا۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -940,6 +1012,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Так!"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جی!"
           }
         },
         "zh-Hans" : {
@@ -1014,6 +1092,12 @@
             "value" : "Ця опція дозволить будь-який (UDP) трафік через порт 53."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ آپشن کسی بھی (UDP) ٹریفک کو پورٹ 53 پر اجازت دے گا۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1084,6 +1168,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дозволити DNS трафік"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DNS ٹریفک کو اجازت دیں"
           }
         },
         "zh-Hans" : {
@@ -1158,6 +1248,12 @@
             "value" : "Безкоштовна, з відкритим кодом, створена однією людиною."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ مفت ہے، اوپن سورس ہے اور ایک ہی (میک لوونگ) کوڈر نے لکھا ہے!"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1228,6 +1324,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Очікується схвалення системного розширення"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سیسٹم ایکسٹینشن کی منظوری کا انتظار"
           }
         },
         "zh-Hans" : {
@@ -1302,6 +1404,12 @@
             "value" : "Бажаєте підтримати?"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کیا آپ ہمیں پیار دکھانا چاہتے ہیں؟"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1372,6 +1480,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Далі"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اگلا"
           }
         },
         "zh-Hans" : {
@@ -1446,6 +1560,12 @@
             "value" : "А тепер давайте налаштуємо LuLu:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اب، ہم LuLu کو تشکیل دیں:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1516,6 +1636,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дозволити вже установлені програми"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پہلے سے انسٹال شدہ ایپلی کیشنز کو اجازت دیں"
           }
         },
         "zh-Hans" : {
@@ -1590,6 +1716,12 @@
             "value" : "Далі"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اگلا"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1662,6 +1794,12 @@
             "value" : "Дозволити програми Apple"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپل پروگرامز کو اجازت دیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1732,6 +1870,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "3. Аутентифікувати"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. تصدیق کریں۔"
           }
         },
         "zh-Hans" : {

--- a/LuLu/LuLu.xcodeproj/project.pbxproj
+++ b/LuLu/LuLu.xcodeproj/project.pbxproj
@@ -509,6 +509,7 @@
 				"zh-Hant",
 				uk,
 				"zh-Hans",
+				"ur"
 			);
 			mainGroup = CDB2CC0F24D61A4E00D0EECE;
 			productRefGroup = CDB2CC1924D61A4E00D0EECE /* Products */;

--- a/LuLu/Shared/Localizable.xcstrings
+++ b/LuLu/Shared/Localizable.xcstrings
@@ -58,6 +58,12 @@
             "value" : " Коефіцієнт виявлення:"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\r\nشناخت کا تناسب: "
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -127,6 +133,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "не знайдено у VirusTotal"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\r\nوائرس ٹوٹل پر نہیں ملا"
           }
         },
         "zh-Hans" : {
@@ -200,6 +212,12 @@
             "value" : "Отримано некоректну відповідь"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\r\nغلط جواب موصول ہوا"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -269,6 +287,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Відкрити у VirusTotal"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\r\nوائرس ٹوٹل کا دیکھیں "
           }
         },
         "zh-Hans" : {
@@ -342,6 +366,12 @@
             "value" : "має проблему з підписом"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " دستخط کا مسئلہ ہے"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -411,6 +441,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "не підписано"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " دستخط شدہ نہیں ہے"
           }
         },
         "zh-Hans" : {
@@ -484,6 +520,12 @@
             "value" : "підпис недійсний"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " درست طریقے سے دستخط شدہ نہیں ہے"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -553,6 +595,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "успішно підписано"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " درست طریقے سے دستخط شدہ ہے"
           }
         },
         "zh-Hans" : {
@@ -626,6 +674,12 @@
             "value" : "невідомий"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " نامعلوم"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -695,6 +749,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "…будь ласка, скопіюйте в /Application і перезапустіть."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "...براہ کرم اسے /ایپلیکیشنز میں کاپی کریں اور دوبارہ شروع کریں۔"
           }
         },
         "zh-Hans" : {
@@ -768,6 +828,12 @@
             "value" : "…це повністю видалить LuLu з вашого Маку"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "...یہ آپ کے میک سے لولو کو مکمل طور پر ہٹا دے گا"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -839,6 +905,12 @@
             "value" : "…це зупинить роботу LuLu до наступного входу."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "...یہ آپ کے اگلے لاگ ان تک لولو کو ختم کر دے گا۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -908,6 +980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "› немає довірених підписантів"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "› دستخط کرنے والے اتھارٹی نہیں ہیں"
           }
         },
         "zh-Hans" : {
@@ -987,6 +1065,12 @@
             "value" : "%1$@ (PID: %2$@) "
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (پی ڈی: %2$@)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1064,6 +1148,12 @@
             "value" : "%1$@ (підписант: %2$@) "
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (دستخط کنندہ: %2$@)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1133,6 +1223,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ (підписант: Apple Mac OS App Store)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (دستخط کنندہ: ایپل میک او ایس ایپ اسٹور)"
           }
         },
         "zh-Hans" : {
@@ -1206,6 +1302,12 @@
             "value" : "%@ (підписант: Apple Proper)"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (دستخط کنندہ: ایپل پروپر)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1275,6 +1377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ (підписант: невалідний/не підписано)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (دستخط کنندہ: غیر معتبر/غیر دستخط شدہ)"
           }
         },
         "zh-Hans" : {
@@ -1348,6 +1456,12 @@
             "value" : "%@ не існує!"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ موجود نہیں ہے!"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1419,6 +1533,12 @@
             "value" : "%@ є легітимним процесом macOS"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ایک قانونی میکس او ایس پروسس ہے"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1488,6 +1608,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ не є валідним номером порту"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ایک درست (پورٹ) نمبر نہیں ہے"
           }
         },
         "zh-Hans" : {
@@ -1567,6 +1693,12 @@
             "value" : "%1$@ не є валідним регулярним виразом  \nДеталі: %2$@"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ ایک درست ریگولر ایکسپریشن نہیں ہے\nتفصیلات: %2$@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1636,6 +1768,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ має неофіційний (ad hoc) підпис"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ تیسری پارٹی/ایڈ ہاک کے ذریعہ دستخط شدہ ہے"
           }
         },
         "zh-Hans" : {
@@ -1709,6 +1847,12 @@
             "value" : "%@ підписано безпосередньо Apple"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ایپل پروپر کے ذریعہ دستخط شدہ ہے"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1778,6 +1922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ підписано Mac App Store"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ میک ایپ اسٹور کے ذریعہ دستخط شدہ ہے"
           }
         },
         "zh-Hans" : {
@@ -1851,6 +2001,12 @@
             "value" : "%@ підписано з Apple Developer ID"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ایپل ڈویلپر آئی ڈی کے ذریعہ دستخط شدہ ہے"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1920,6 +2076,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "помилка підпису: %#lx"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ دستخطی خطا: %#lx"
           }
         },
         "zh-Hans" : {
@@ -1993,6 +2155,12 @@
             "value" : "%@ це правило може вплинути на коректну роботу системи... Продовжити?"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ اس قاعدہ سے، قانونی سسٹم کی کارکردگی پر اثر پڑ سکتا ہے ... جاری رکھیں؟"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2062,6 +2230,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Інформація щодо підпису коду %@ змінилася"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ کی کوڈ دستخط کی معلومات تبدیل ہو گئی ہیں"
           }
         },
         "zh-Hans" : {
@@ -2135,6 +2309,12 @@
             "value" : "→ Видалити правило"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "→ قاعدہ حذف کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2204,6 +2384,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "→ Видалити правило/правила"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "→ قاعدہ/قواعد حذف کریں"
           }
         },
         "zh-Hans" : {
@@ -2277,6 +2463,12 @@
             "value" : "→ Редагувати правило"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "→ قاعدہ میں ترمیم کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2346,6 +2538,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "→ Показати шлях/шляхи"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "→ راستے(راستے) دکھائیں"
           }
         },
         "zh-Hans" : {
@@ -2419,6 +2617,12 @@
             "value" : "<невідомий (%d)>"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "<نامعلوم (%d)>"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2488,6 +2692,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "2. У «Системних параметрах» прокрутіть до LuLu і натисніть «Дозволити»."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. سسٹم سیٹنگز میں، 'LuLu' کے ذکر کردہ مقام پر اسکرول کریں اور 'الاؤ' پر کلک کریں۔"
           }
         },
         "zh-Hans" : {
@@ -2561,6 +2771,12 @@
             "value" : "2. У «Системних параметрах» увімкніть розширення LuLu."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. سسٹم سیٹنگز میں، LuLu ایکسٹینشن کو آن کریں۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2630,6 +2846,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "доступна нова версія (%@)!"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایک نئی ورژن (%@) دستیاب ہے!"
           }
         },
         "zh-Hans" : {
@@ -2703,6 +2925,12 @@
             "value" : "Ad hoc"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایڈ ہاک"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2772,6 +3000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : " Додано за останні 24 години (відсортовано за часом створення)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "گذشتہ 24 گھنٹوں میں شامل کیا گیا (تخلیق کے وقت کے مطابق ترتیب دیا گیا)"
           }
         },
         "zh-Hans" : {
@@ -2845,6 +3079,12 @@
             "value" : "Всі правила"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تمام قواعد"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2914,6 +3154,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дозволити"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الاؤ"
           }
         },
         "zh-Hans" : {
@@ -2987,6 +3233,12 @@
             "value" : "Дозволити (PID: %@)"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الاؤ (پی آئی ڈی: %@)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3056,6 +3308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дозволити (до: %@)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الاؤ (تک: %@)"
           }
         },
         "zh-Hans" : {
@@ -3129,6 +3387,12 @@
             "value" : "будь-яка адреса"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کوئی بھی پتہ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3198,6 +3462,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "будь-який порт"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کوئی بھی پورٹ"
           }
         },
         "zh-Hans" : {
@@ -3271,6 +3541,12 @@
             "value" : "Будь-яка програма"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کوئی بھی پروگرام"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3340,6 +3616,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Програми Apple (автоматично дозволяються й додаються сюди, якщо увімкнено «Дозволяти програми Apple»)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایپل پروگرامز (اگر 'ایپل پروگرامز کو الاؤ' سیٹ کیا جائے تو خودکار طور پر یہاں شامل اور الاؤ دیا جاتا ہے)"
           }
         },
         "zh-Hans" : {
@@ -3413,6 +3695,12 @@
             "value" : "Блокувати"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلاک"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3482,6 +3770,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Блокувати (PID: %@)"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلاک کریں (پی آئی ڈی: %@)"
           }
         },
         "zh-Hans" : {
@@ -3555,6 +3849,12 @@
             "value" : "Блокувати (до: %@)"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بلاک کریں (تک: %@)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3624,6 +3924,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Скасувати"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منسوخ کریں"
           }
         },
         "zh-Hans" : {
@@ -3697,6 +4003,12 @@
             "value" : "Видалити правила, що посилаються на видалені, прострочені або завершені елементи?"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف شدہ، ختم شدہ یا ختم شدہ اشیاء کے حوالے سے قواعد کو صاف کرنا چاہتے ہیں؟"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3766,6 +4078,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалено %ld правил"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%ld قواعد کو صاف کیا گیا"
           }
         },
         "zh-Hans" : {
@@ -3839,6 +4157,12 @@
             "value" : "Продовжити"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جاری رکھیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3908,6 +4232,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Правила каталогів застосовуються до всіх елементів у каталозі."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ڈائریکٹری قواعد ڈائریکٹری کے اندر موجود تمام اشیاء پر لاگو ہوتی ہیں۔"
           }
         },
         "zh-Hans" : {
@@ -3981,6 +4311,12 @@
             "value" : "Вимкнути"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "غیر فعال کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4050,6 +4386,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Увімкнути"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فعال کریں"
           }
         },
         "zh-Hans" : {
@@ -4123,6 +4465,12 @@
             "value" : "ПОМИЛКА: активація не вдалася"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خطا: فعال کرنے میں ناکامی"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4137,7 +4485,7 @@
         }
       }
     },
-    "ERROR: Failed to cleanup rules" : {
+        "ERROR: Failed to cleanup rules" : {
       "comment" : "ERROR: Failed to cleanup rules",
       "localizations" : {
         "de" : {
@@ -4192,6 +4540,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ПОМИЛКА: не вдалося видалити правила"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خرابی: اصولوں کی صفائی میں ناکامی"
           }
         },
         "zh-Hans" : {
@@ -4265,6 +4619,12 @@
             "value" : "ПОМИЛКА: не вдалося експортувати правила"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خرابی: اصولوں کو برآمد کرنے میں ناکامی"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4334,6 +4694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ПОМИЛКА: не вдалося імпортувати правила"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خرابی: اصولوں کو درآمد کرنے میں ناکامی"
           }
         },
         "zh-Hans" : {
@@ -4407,6 +4773,12 @@
             "value" : "ПОМИЛКА: не вдалося завантажити список патронів"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خرابی: سرپرستوں کو لوڈ کرنے میں ناکامی"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4476,6 +4848,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ПОМИЛКА: некоректний шлях"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خرابی: نا درست راستہ"
           }
         },
         "zh-Hans" : {
@@ -4549,6 +4927,12 @@
             "value" : "ПОМИЛКА: некоректний порт"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خرابی: نا درست پورٹ"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4618,6 +5002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ПОМИЛКА: некоректний регулярний вираз"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خرابی: نا درست ریگولر ایکسپریشن"
           }
         },
         "zh-Hans" : {
@@ -4691,6 +5081,12 @@
             "value" : "ПОМИЛКА: не вдалося перевірити оновлення"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خرابی: اپ ڈیٹ چیک میں ناکامی"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4760,6 +5156,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Розширення потрібно схвалити вручну в «Налаштуваннях безпеки» (Загальні > Автозапуск і розширення > Мережеві розширення)."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ایکسٹینشنز کو مینوئل طور پر سسٹم سیٹنگز (جنرل > لاگ ان آئٹمز اینڈ ایکسٹینشنز > نیٹ ورک ایکسٹینشنز) کے ذریعے منظور کرنا ہوگا۔"
           }
         },
         "zh-Hans" : {
@@ -4833,6 +5235,12 @@
             "value" : "не вдалося активувати мережеве розширення"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نیٹ ورک ایکسٹینشن کو فعال کرنے میں ناکامی"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4902,6 +5310,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "не вдалося активувати мережевий фільтр"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نیٹ ورک فلٹر کو فعال کرنے میں ناکامی"
           }
         },
         "zh-Hans" : {
@@ -4975,6 +5389,12 @@
             "value" : "не вдалося активувати системне розширення"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سسٹم ایکسٹینشن کو فعال کرنے میں ناکامی"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5044,6 +5464,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "не вдалося активувати системне або мережеве розширення"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سسٹم/نیٹ ورک ایکسٹینشن کو فعال کرنے میں ناکامی"
           }
         },
         "zh-Hans" : {
@@ -5117,6 +5543,12 @@
             "value" : "Не вдалося виконати запит до VirusTotal"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وائرس ٹوٹل کو کوئری کرنے میں ناکامی"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5186,6 +5618,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "результати аналізу"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نتائج"
           }
         },
         "zh-Hans" : {
@@ -5259,6 +5697,12 @@
             "value" : "Повний URL: %@"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مکمل یو آر ایل: %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5328,6 +5772,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Глобальні правила застосовуються до всіх шляхів"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "گلوبل رولز تمام راستوں پر لاگو ہوتے ہیں"
           }
         },
         "zh-Hans" : {
@@ -5401,6 +5851,12 @@
             "value" : "Імпортовано %ld правил"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%ld رولز درآمد کیے گئے"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5470,6 +5926,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Встановлена версія (%@) є найновішою."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انسٹال ورژن (%@)،\r\nسب سے تازہ ترین ہے۔"
           }
         },
         "zh-Hans" : {
@@ -5543,6 +6005,12 @@
             "value" : "підключається до %@"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "منسلک ہو رہا ہے %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5564,6 +6032,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ключ"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کلید"
           }
         }
       },
@@ -5624,6 +6098,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LuLu має працювати з:\r\n  %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu کو یہاں سے چلانا ہوگا:\r\n  %@"
           }
         },
         "zh-Hans" : {
@@ -5697,6 +6177,12 @@
             "value" : "LuLu: вимкнено"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu: غیر فعال"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5766,6 +6252,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LuLu: увімкнено"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu: فعال"
           }
         },
         "zh-Hans" : {
@@ -5839,6 +6331,12 @@
             "value" : "Мережеве розширення LuLu не працює"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LuLu کا نیٹ ورک ایکسٹینشن چل رہا نہیں ہے"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5908,6 +6406,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Більше інформації"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مزید معلومات"
           }
         },
         "zh-Hans" : {
@@ -5981,6 +6485,12 @@
             "value" : "жоден"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "کوئی نہیں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6050,6 +6560,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "не застосовується"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لاگو نہیں"
           }
         },
         "zh-Hans" : {
@@ -6123,6 +6639,12 @@
             "value" : "Зверніть увагу:\n▪ Існуючі з'єднання не будуть порушені.  \n▪ Системний трафік, який не проходить через LuLu, не буде заблоковано."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "یہ نوٹ کریں:\r\n▪ موجودہ کنیکشن پر کوئی اثر نہیں پڑے گا۔\r\n▪ او ایس ٹریفک (جو لولو کے ذریعے روٹ نہیں کیا جاتا ہے) کو بلاک نہیں کیا جائے گا۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6194,6 +6716,12 @@
             "value" : "ОК"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ٹھیک ہے"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6208,7 +6736,7 @@
         }
       }
     },
-    "Old Version of LuLu Installed" : {
+        "Old Version of LuLu Installed" : {
       "comment" : "Old Version of LuLu Installed",
       "localizations" : {
         "de" : {
@@ -6256,13 +6784,19 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LuLu’nun eski sürümü kurulu"
+            "value" : "LuLu'nun eski sürümü kurulu"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Виявлено застарілу версію LuLu"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو کا پرانا ورژن انسٹال ہے"
           }
         },
         "zh-Hans" : {
@@ -6336,6 +6870,12 @@
             "value" : "Системні програми (необхідні для роботи операційної системи)"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آپریٹنگ سسٹم پروگرامز (سسٹم فنکشنیلٹی کے لیے ضروری)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6405,6 +6945,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вихідний трафік тепер буде заблоковано."
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آؤٹ گوئنگ ٹریفک اب بلاک کر دی جائے گی۔"
           }
         },
         "zh-Hans" : {
@@ -6478,6 +7024,12 @@
             "value" : "Попередньо встановлені сторонні програми (автоматично дозволяються й додаються сюди, якщо увімкнено «Дозволити встановлені програми»)"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پہلے سے انسٹال شدہ تھرڈ پارٹی پروگرامز (اگر 'انسٹال شدہ ایپلیکیشنز کو اجازت دیں' سیٹ ہو تو خودکار طور پر اجازت دی جاتی ہے اور یہاں شامل کی جاتی ہے)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6547,6 +7099,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Параметри процесу: %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پروسیس آرگومنٹس: %@"
           }
         },
         "zh-Hans" : {
@@ -6620,10 +7178,16 @@
             "value" : "Шлях процесу: %@"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پروسیس پاتھ: %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "进程路径：％@"
+            "value" : "进程路径：%@"
           }
         },
         "zh-Hant" : {
@@ -6689,6 +7253,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Програми в \"%@/\""
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "پروگرامز اندر \"%@/\""
           }
         },
         "zh-Hans" : {
@@ -6762,6 +7332,12 @@
             "value" : "Виконується запит до VirusTotal..."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وائرس ٹوٹل کو تلاش کر رہا ہے..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6831,6 +7407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Завершити"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ختم کریں"
           }
         },
         "zh-Hans" : {
@@ -6904,6 +7486,12 @@
             "value" : "Завершити роботу з LuLu?"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو کو ختم کریں؟"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6975,6 +7563,12 @@
             "value" : "Зворотний домен: %@"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ریورس ڈومین: %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7011,6 +7605,12 @@
           }
         },
         "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "rules.json"
+          }
+        },
+        "ur" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "rules.json"
@@ -7074,6 +7674,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дивіться лог для детальнішої інформації"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مزید تفصیلات کے لیے لاگ دیکھیں"
           }
         },
         "zh-Hans" : {
@@ -7147,6 +7753,12 @@
             "value" : "Щоб продовжити, необхідно це видалити. Натисніть «Більше інформації», щоб дізнатися, як це видалити."
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اسے جاری رکھنے سے پہلے ان انسٹال کرنا ہوگا۔ مزید معلومات کے لیے 'مزید معلومات' پر کلک کریں۔"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7216,6 +7828,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Мітка часу: %@"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ٹائم اسٹیمپ: %@"
           }
         },
         "zh-Hans" : {
@@ -7289,6 +7907,12 @@
             "value" : "Видалити"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انسٹال کریں"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7358,6 +7982,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити LuLu?"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لولو کو ان انسٹال کریں؟"
           }
         },
         "zh-Hans" : {
@@ -7431,6 +8061,12 @@
             "value" : "невідомий"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نامعلوم"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7500,6 +8136,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Оновити"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اپ ڈیٹ"
           }
         },
         "zh-Hans" : {
@@ -7590,6 +8232,12 @@
             "value" : "Програми, вказані користувачем (додані вручну або у відповідь на сповіщення)"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "صارف کے ذریعہ مخصوص پروگرامز (مینیول طور پر شامل کیے گئے ہیں، یا انتباہ کے جواب میں)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7661,6 +8309,12 @@
             "value" : "Версія: %@"
           }
         },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ورژن: %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7730,6 +8384,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Очікується схвалення мережевого розширення"
+          }
+        },
+        "ur" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نیٹ ورک ایکسٹینشن کی منظوری کا انتظار"
           }
         },
         "zh-Hans" : {

--- a/LuLu/Shared/Localizable.xcstrings
+++ b/LuLu/Shared/Localizable.xcstrings
@@ -4485,7 +4485,7 @@
         }
       }
     },
-        "ERROR: Failed to cleanup rules" : {
+    "ERROR: Failed to cleanup rules" : {
       "comment" : "ERROR: Failed to cleanup rules",
       "localizations" : {
         "de" : {
@@ -6736,7 +6736,7 @@
         }
       }
     },
-        "Old Version of LuLu Installed" : {
+    "Old Version of LuLu Installed" : {
       "comment" : "Old Version of LuLu Installed",
       "localizations" : {
         "de" : {
@@ -6784,7 +6784,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LuLu'nun eski sürümü kurulu"
+            "value" : "LuLu’nun eski sürümü kurulu"
           }
         },
         "uk" : {
@@ -7187,7 +7187,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "进程路径：%@"
+            "value" : "进程路径：％@"
           }
         },
         "zh-Hant" : {


### PR DESCRIPTION
# Add Urdu (ur) Localization to LuLu

## Description
This PR adds comprehensive Urdu language support to the LuLu application, making it more accessible to Urdu-speaking users. The localization includes translations for all user-facing text elements throughout the application.

## Changes
- Added Urdu translations to the following interface elements:
  - Application info (InfoPlist.xcstrings)
  - About window
  - Add Rule dialog
  - Alert windows
  - Item paths
  - Main menu
  - Preferences panel
  - Rules management interface
  - Startup windows
  - Status bar popover
  - Update window
  - Welcome screens
  - General localizable strings

- Updated project configuration (project.pbxproj) to include Urdu as a supported language
