### PR TITLE
Fix missing comma in DEFAULT_RULES causing silent string concatenation

### DIFF
--- a/LuLu/Extension/Rules.m
+++ b/LuLu/Extension/Rules.m
@@ -19,7 +19,7 @@
 NSString* const DEFAULT_RULES[] =
 {
     @"/System/Library/PrivateFrameworks/ApplePushService.framework/apsd",
-    @"/System/Library/PrivateFrameworks/AssistantServices.framework/Versions/A/Support/assistantd"
+    @"/System/Library/PrivateFrameworks/AssistantServices.framework/Versions/A/Support/assistantd",
     @"/usr/sbin/automount",
     @"/System/Library/PrivateFrameworks/HelpData.framework/Versions/A/Resources/helpd",
     @"/usr/sbin/mDNSResponder",


### PR DESCRIPTION
### Summary

- **Fix critical missing comma** in `DEFAULT_RULES` array (`Rules.m:22`) that caused C string literal concatenation, silently merging the `assistantd` and `automount` paths into one invalid entry
- This resulted in both `assistantd` and `/usr/sbin/automount` having **no default allow rule**, generating unnecessary firewall alerts for these Apple system processes
- The array contained 9 elements instead of the intended 10, affecting the `sizeof` calculation used for iteration

### Details

In C/Objective-C, adjacent string literals without a comma are automatically concatenated by the compiler — **without any warning**. The missing comma after line 22:

```objc
// Before (bug):
@".../assistantd"
@"/usr/sbin/automount",   // concatenated into one garbage string

// After (fix):
@".../assistantd",         // comma added
@"/usr/sbin/automount",   // now a separate, correct entry
```

The concatenated result was:
```
/System/Library/PrivateFrameworks/AssistantServices.framework/Versions/A/Support/assistantd/usr/sbin/automount
```

This path never matches any real binary, so `fileExistsAtPath:` skips it silently during default rule generation.

### Impact

| Process | Expected | Actual (before fix) |
|---------|----------|-------------------|
| `assistantd` | Default allow rule | No rule (alerts user) |
| `/usr/sbin/automount` | Default allow rule | No rule (alerts user) |
| `DEFAULT_RULES` array size | 10 elements | 9 elements |

### Test plan

- [ ] Verify `DEFAULT_RULES` array now contains 10 elements
- [ ] Fresh install: confirm both `assistantd` and `automount` appear in default rules
- [ ] Verify no unnecessary firewall alerts for `assistantd` or `automount` on clean install
- [ ] Existing installs with user-created rules for these processes remain unaffected