### PR TITLE
[Feature] If process's parent has blocking rule, use it

### DIFF
--- a/LuLu/Extension/Rules.m
+++ b/LuLu/Extension/Rules.m
@@ -902,6 +902,24 @@ bail:
         
         //any match?
         else if (nil != anyMatch) matchingRule = anyMatch;
+
+        //no matching rule found for child process?
+        // check ancestors for blocking rules
+        if(nil == matchingRule)
+        {
+            //dbg msg
+            os_log_debug(logHandle, "no direct rule found for %{public}@, checking ancestors...", process.path);
+            
+            //check ancestors
+            matchingRule = [self findRuleForAncestors:process];
+            
+            //rule found?
+            if(nil != matchingRule)
+            {
+                //dbg msg
+                os_log_debug(logHandle, "inherited blocking rule from ancestor: %{public}@", matchingRule);
+            }
+        }
     
     }//sync
         
@@ -1089,6 +1107,139 @@ bail:
 bail:
         
     return isMatch;
+}
+
+// Check if an ancestor has a blocking rule
+// Returns the blocking rule if found
+-(Rule*)findRuleForAncestors:(Process*)process
+{
+    //dbg msg
+    os_log_debug(logHandle, "checking ancestors for blocking rules");
+    
+    //iterate through ancestors
+    for(NSDictionary* ancestor in process.ancestors)
+    {
+        //ancestor dictionary
+        NSDictionary* ancestor = nil;
+        
+        //ancestor path
+        NSString* ancestorPath = nil;
+        
+        //ancestor key
+        NSString* ancestorKey = nil;
+        
+        //ancestor rule
+        Rule* ancestorRule = nil;
+        
+        //extract ancestor
+        ancestor = process.ancestors[i];
+        ancestorPath = ancestor[KEY_PROCESS_PATH];
+        
+        //skip invalid ancestor
+        if(0 == ancestorPath.length)
+        {
+            continue;
+        }
+        
+        //sync to access rules dictionary
+        @synchronized(self.rules)
+        {
+            //check 1: direct path match
+            if(nil != self.rules[ancestorPath])
+            {
+                //dbg msg
+                os_log_debug(logHandle, "found ancestor rule by path: %{public}@", ancestorPath);
+                
+                //get ancestor rules
+                NSArray* ancestorRules = self.rules[ancestorPath][KEY_RULES];
+                
+                //check each rule for block
+                for(Rule* rule in ancestorRules)
+                {
+                    //only care about blocking rules
+                    if(RULE_STATE_BLOCK == rule.action.integerValue)
+                    {
+                        //dbg msg
+                        os_log_debug(logHandle, "ancestor has blocking rule: %{public}@", rule);
+                        
+                        //return blocking rule
+                        return rule;
+                    }
+                }
+            }
+            
+            //check 2: lazy CS info fetch
+            // only if path matching failed
+            {
+                //init cs flags
+                SecCSFlags flags = kSecCSDefaultFlags | kSecCSCheckNestedCode | kSecCSDoNotValidateResources | kSecCSCheckAllArchitectures;
+                
+                //extract signing info for ancestor
+                // note: we use the path, not a token
+                NSMutableDictionary* ancestorCSInfo = nil;
+                @try
+                {
+                    ancestorCSInfo = extractSigningInfo(0, ancestorPath, flags);
+                }
+                @catch(NSException* exception)
+                {
+                    //err msg
+                    os_log_error(logHandle, "ERROR: failed to extract CS info for ancestor: %{public}@ (exception: %{public}@)", ancestorPath, exception);
+                    
+                    //skip this ancestor
+                    continue;
+                }
+                
+                //skip if no CS info
+                if(nil == ancestorCSInfo)
+                {
+                    //dbg msg
+                    os_log_debug(logHandle, "failed to extract CS info for ancestor: %{public}@", ancestorPath);
+                    
+                    //skip this ancestor
+                    continue;
+                }
+                
+                // Get keyPath with same logic as for actual process
+                NSString* ancestorKey = [Rule generateKeyForPath:ancestorPath csInfo:ancestorCSInfo];
+                
+                //no valid key?
+                // fall back to path (already checked above)
+                if(0 == ancestorKey.length)
+                {
+                    //skip this ancestor
+                    continue;
+                }
+                
+                //check if rule exists for ancestor CS key
+                if(nil != self.rules[ancestorKey])
+                {
+                    //dbg msg
+                    os_log_debug(logHandle, "found ancestor rule by CS key: %{public}@", ancestorKey);
+                    
+                    //get ancestor rules
+                    NSArray* ancestorRules = self.rules[ancestorKey][KEY_RULES];
+                    
+                    //check each rule for block
+                    for(Rule* rule in ancestorRules)
+                    {
+                        //only care about blocking rules
+                        if(RULE_STATE_BLOCK == rule.action.integerValue)
+                        {
+                            //dbg msg
+                            os_log_debug(logHandle, "ancestor has blocking rule: %{public}@", rule);
+                            
+                            //return blocking rule
+                            return rule;
+                        }
+                    }
+                }
+            }
+        } //sync
+    } //iterate ancestors
+    
+    //no blocking rules found in ancestors
+    return nil;
 }
 
 //toggle rule

--- a/LuLu/Extension/Rules.m
+++ b/LuLu/Extension/Rules.m
@@ -1131,8 +1131,7 @@ bail:
         //ancestor rule
         Rule* ancestorRule = nil;
         
-        //extract ancestor
-        ancestor = process.ancestors[i];
+        //extract ancestor path
         ancestorPath = ancestor[KEY_PROCESS_PATH];
         
         //skip invalid ancestor

--- a/LuLu/Shared/Rule.h
+++ b/LuLu/Shared/Rule.h
@@ -113,6 +113,9 @@
 //make a rule obj from a dictioanary
 -(id)initFromJSON:(NSDictionary*)info;
 
+//generate matching key for Process's path
+(NSString *)generateKeyForPath:(NSString *)path csInfo:(NSDictionary *)csInfo;
+
 @end
 
 #endif /* Rule_h */

--- a/LuLu/Shared/Rule.h
+++ b/LuLu/Shared/Rule.h
@@ -114,7 +114,7 @@
 -(id)initFromJSON:(NSDictionary*)info;
 
 //generate matching key for Process's path
-(NSString *)generateKeyForPath:(NSString *)path csInfo:(NSDictionary *)csInfo;
++(NSString *)generateKeyForPath:(NSString *)path csInfo:(NSDictionary *)csInfo;
 
 @end
 

--- a/LuLu/Shared/Rule.m
+++ b/LuLu/Shared/Rule.m
@@ -143,6 +143,11 @@ extern os_log_t logHandle;
 // note: this matches process' generate key algo
 -(NSString*)generateKey
 {
+    return [self.class keyForPath:self.path csInfo:self.csInfo]
+}
+
+(NSString *)generateKeyForPath:(NSString *)path csInfo:(NSDictionary *)csInfo
+{
     //id
     NSString* key = nil;
     
@@ -150,10 +155,10 @@ extern os_log_t logHandle;
     NSInteger signer = None;
     
     //cs info?
-    if(nil != self.csInfo)
+    if(nil != csInfo)
     {
         //extract signer
-        signer = [self.csInfo[KEY_CS_SIGNER] intValue];
+        signer = [csInfo[KEY_CS_SIGNER] intValue];
         
         //apple/app store
         // just use cs id
@@ -161,7 +166,7 @@ extern os_log_t logHandle;
             (AppStore == signer) )
         {
             //set key
-            key = self.csInfo[KEY_CS_ID];
+            key = csInfo[KEY_CS_ID];
         }
         
         //dev id?
@@ -169,11 +174,11 @@ extern os_log_t logHandle;
         else if(DevID == signer)
         {
             //check for cs id/auths
-            if( (0 != [self.csInfo[KEY_CS_ID] length]) &&
-                (0 != [self.csInfo[KEY_CS_AUTHS] count]) )
+            if( (0 != [csInfo[KEY_CS_ID] length]) &&
+                (0 != [csInfo[KEY_CS_AUTHS] count]) )
             {
                 //set
-                key = [NSString stringWithFormat:@"%@:%@", self.csInfo[KEY_CS_ID], [self.csInfo[KEY_CS_AUTHS] firstObject]];
+                key = [NSString stringWithFormat:@"%@:%@", csInfo[KEY_CS_ID], [csInfo[KEY_CS_AUTHS] firstObject]];
             }
         }
     }
@@ -183,7 +188,7 @@ extern os_log_t logHandle;
     if(0 == key.length)
     {
         //set
-        key = self.path;
+        key = path;
     }
     
     //dbg msg

--- a/LuLu/Shared/Rule.m
+++ b/LuLu/Shared/Rule.m
@@ -143,10 +143,10 @@ extern os_log_t logHandle;
 // note: this matches process' generate key algo
 -(NSString*)generateKey
 {
-    return [self.class keyForPath:self.path csInfo:self.csInfo]
+    return [self.class generateKeyForPath:self.path csInfo:self.csInfo];
 }
 
-(NSString *)generateKeyForPath:(NSString *)path csInfo:(NSDictionary *)csInfo
++(NSString *)generateKeyForPath:(NSString *)path csInfo:(NSDictionary *)csInfo
 {
     //id
     NSString* key = nil;


### PR DESCRIPTION
Use Case:
Parent app already has a blocking rule, but it spawns child-processes that still can make network requests.

Only ancestors' blocking rules are used in case the original matching rules were not found.

---

I don't have a paid Apple Developer account, so it seems I'm not able to build/run/test this one locally due to it's network extensions. If someone can help me with that one, I would appreciate it.

---

Warning: I'm not an Objective-C developer myself, so most of the code has been LLM generated with locally run Qwen3.5. I did read and iterate this one a few times myself, and tried to match the existing formatting and coding style as much as possible. In other words, this PR should not be merged as such without testing, and might only be used as proof-of-concept for the idea.