### PR TITLE
fix: prevent profile sheet subviews from covering the Next button

### DIFF
--- a/LuLu/App/PrefsWindowController.m
+++ b/LuLu/App/PrefsWindowController.m
@@ -779,7 +779,8 @@ bail:
     self.currentProfileSubview = self.profileNameView;
     
     //add initial (profile name) view
-    [self.addProfileSheet.contentView addSubview:self.currentProfileSubview];
+    // position below buttons to prevent content view from covering them
+    [self.addProfileSheet.contentView addSubview:self.currentProfileSubview positioned:NSWindowBelow relativeTo:self.continueProfileButton];
     
     //disable autoresizing mask
     self.currentProfileSubview.translatesAutoresizingMaskIntoConstraints = NO;
@@ -902,7 +903,7 @@ bail:
             self.showRulesButton.hidden = YES;
             
             //add to rule's view
-            [self.addProfileSheet.contentView addSubview:self.currentProfileSubview];
+            [self.addProfileSheet.contentView addSubview:self.currentProfileSubview positioned:NSWindowBelow relativeTo:self.continueProfileButton];
             
             //update tag
             self.continueProfileButton.tag = profileRules;
@@ -921,8 +922,8 @@ bail:
             self.currentProfileSubview = self.modesView;
             
             //add to mode's view
-            [self.addProfileSheet.contentView addSubview:self.currentProfileSubview];
-            
+            [self.addProfileSheet.contentView addSubview:self.currentProfileSubview positioned:NSWindowBelow relativeTo:self.continueProfileButton];
+
             //update tag
             self.continueProfileButton.tag = profileModes;
             
@@ -939,7 +940,7 @@ bail:
             self.currentProfileSubview = self.listsView;
             
             //add to list's view
-            [self.addProfileSheet.contentView addSubview:self.currentProfileSubview];
+            [self.addProfileSheet.contentView addSubview:self.currentProfileSubview positioned:NSWindowBelow relativeTo:self.continueProfileButton];
             
             //update tag
             self.continueProfileButton.tag = profileLists;
@@ -962,9 +963,9 @@ bail:
             //unset label
             self.updateLabel.stringValue = @"";
             
-            //add to mode's view
-            [self.addProfileSheet.contentView addSubview:self.currentProfileSubview];
-            
+            //add to update's view
+            [self.addProfileSheet.contentView addSubview:self.currentProfileSubview positioned:NSWindowBelow relativeTo:self.continueProfileButton];
+
             //update tag
             self.continueProfileButton.tag = profileUpdates;
             


### PR DESCRIPTION
## Problem

When adding a new profile via **Preferences → Profiles → Add Profile**, each step's content subview (profile name, rules, modes, lists, updates) was added to the sheet's `contentView` using a plain `addSubview:` call. This placed the new subview at the top of the z-order, rendering it on top of the **Cancel** and **Next/Add Profile** buttons and making them impossible to click.

## Root Cause

`addSubview:` appends the view above all existing siblings in z-order. Since `continueProfileButton` and the cancel button are already subviews of `addProfileSheet.contentView`, any subsequently added content subview covers them.

## Fix

Replace all 5 plain `addSubview:self.currentProfileSubview` calls in `PrefsWindowController.m` with:

```objc
[self.addProfileSheet.contentView addSubview:self.currentProfileSubview
    positioned:NSWindowBelow
    relativeTo:self.continueProfileButton];
```

This ensures every content subview is inserted below `continueProfileButton` in z-order, keeping the navigation buttons always visible and clickable across all 5 steps of the profile creation wizard.

## Steps to Reproduce

1. Open LuLu Preferences
2. Navigate to the **Profiles** tab
3. Click **Add Profile**
4. Observe that the **Next** button is covered and unclickable

## Testing

Manually verified all 5 steps of the profile creation sheet — profile name, rules, modes, lists, and updates — confirming the Cancel and Next/Add Profile buttons remain visible and clickable throughout the entire flow.