### PR TITLE
xpc: replace synchronous daemon calls with async completion-block API

### DIFF
--- a/LuLu/App/AlertWindowController.m
+++ b/LuLu/App/AlertWindowController.m
@@ -113,9 +113,18 @@ extern NSMutableDictionary* alerts;
     
     //extract process ID
     processID = [self.alert[KEY_PROCESS_ID] intValue];
-    
-    //get preferences
-    preferences = [xpcDaemonClient getPreferences];
+
+    {
+        __block NSDictionary* loadedPrefs = nil;
+        dispatch_semaphore_t prefsSem = dispatch_semaphore_create(0);
+        [xpcDaemonClient getPreferences:^(NSDictionary* prefs) {
+            loadedPrefs = prefs;
+            dispatch_semaphore_signal(prefsSem);
+        }];
+        //wait up to 2s; XPC error handler signals immediately on failure
+        dispatch_semaphore_wait(prefsSem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)));
+        preferences = loadedPrefs ?: @{};
+    }
     
     //do we have access?
     // build hierarchy here
@@ -840,11 +849,11 @@ bail:
         [alerts removeObjectForKey:self.alert[KEY_UUID]];
     }
     
-    //save preferences
+    //save preferences (async; result not needed)
     // includes options shown/last action scope, etc.
     [xpcDaemonClient updatePreferences:@{PREF_ALERT_SHOW_OPTIONS: @(showOptionsState),
                                          PREF_ALERT_LAST_RULE_SCOPE: @(ruleScopeIndex),
-                                         PREF_ALERT_LAST_RULE_DURATION: @(ruleDurationTag)}];
+                                         PREF_ALERT_LAST_RULE_DURATION: @(ruleDurationTag)} completion:nil];
     
     //set app's background/foreground state
     [((AppDelegate*)[[NSApplication sharedApplication] delegate]) setActivationPolicy];

--- a/LuLu/App/AppDelegate.m
+++ b/LuLu/App/AppDelegate.m
@@ -608,69 +608,63 @@ bail:
 // includes enabling network ext if user hasn't disabled
 -(void)completeInitialization:(NSDictionary*)initialPreferences
 {
-    //preferences
-    NSDictionary* preferences = nil;
-       
     //dbg msg
     os_log_debug(logHandle, "method '%s' invoked", __PRETTY_FUNCTION__);
-    
+
     //alloc array for alert (windows)
     alerts = [NSMutableDictionary dictionary];
-    
+
     //init extension comms
     // establishes connection to extension
     xpcDaemonClient = [[XPCDaemonClient alloc] init];
-    
+
     //initial prefs?
-    // send to extension
+    // send to extension (fire-and-forget)
     if(nil != initialPreferences)
     {
-        //set prefs
-        [xpcDaemonClient updatePreferences:initialPreferences];
+        [xpcDaemonClient updatePreferences:initialPreferences completion:nil];
     }
-    
+
     //always (reset) disabled
-    // always want enabled on (restart)
-    preferences = [xpcDaemonClient updatePreferences:@{PREF_IS_DISABLED:@NO}];
-    
-    //dbg msg
-    os_log_debug(logHandle, "loaded preferences %{public}@", preferences);
-    
-    //run with status bar icon?
-    if(YES != [preferences[PREF_NO_ICON_MODE] boolValue])
-    {
-        //alloc/load nib
-        statusBarItemController = [[StatusBarItem alloc] init:self.statusMenu preferences:(NSDictionary*)preferences];
-        
-        //dbg msg
-        os_log_debug(logHandle, "initialized/loaded status bar (icon/menu)");
-    }
-    else
-    {
-        //dbg msg
-        os_log_debug(logHandle, "running in 'no icon' mode (so no need for status bar)");
-    }
-    
-    //cleanup any expired/temp rules
-    [xpcDaemonClient cleanupRules:NO];
-    
-    //automatically check for updates?
-    // skipped if launched by user (e.g. first time run)
-    if( (YES != launchedByUser()) &&
-        (YES != [preferences[PREF_NO_UPDATE_MODE] boolValue]) )
-    {
-        //after a 30 seconds
-        // check for updates in background
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^
-        {
+    // always want enabled on (re)start; daemon replies with the merged prefs,
+    // which we use to set up the status bar + auto-update check
+    [xpcDaemonClient updatePreferences:@{PREF_IS_DISABLED:@NO} completion:^(NSDictionary* preferences) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            //fallback to empty dict on XPC failure (status bar shows w/ defaults)
+            NSDictionary* prefs = preferences ?: @{};
+
             //dbg msg
-            os_log_debug(logHandle, "checking for update...");
-           
-            //check
-            [self check4Update];
-       });
-    }
-    
+            os_log_debug(logHandle, "loaded preferences %{public}@", prefs);
+
+            //run with status bar icon?
+            if(YES != [prefs[PREF_NO_ICON_MODE] boolValue])
+            {
+                statusBarItemController = [[StatusBarItem alloc] init:self.statusMenu preferences:prefs];
+                os_log_debug(logHandle, "initialized/loaded status bar (icon/menu)");
+            }
+            else
+            {
+                os_log_debug(logHandle, "running in 'no icon' mode (so no need for status bar)");
+            }
+
+            //automatically check for updates?
+            // skipped if launched by user (e.g. first time run)
+            if( (YES != launchedByUser()) &&
+                (YES != [prefs[PREF_NO_UPDATE_MODE] boolValue]) )
+            {
+                //after 30 seconds, check for updates in background
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                    os_log_debug(logHandle, "checking for update...");
+                    [self check4Update];
+                });
+            }
+        });
+    }];
+
+    //cleanup any expired/temp rules (async; result ignored)
+    [xpcDaemonClient cleanupRules:NO completion:nil];
+
     return;
 }
 

--- a/LuLu/App/Configure.m
+++ b/LuLu/App/Configure.m
@@ -137,17 +137,30 @@ bail:
     //dbg msg
     os_log_debug(logHandle, "function '%s' invoked", __PRETTY_FUNCTION__);
     
-    //tell ext. to uninstall
-    // remove rules, etc, etc
-    if(YES != [xpcDaemonClient uninstall])
+    //tell ext. to uninstall — remove rules, etc.
+    // NOTE: this MUST complete before we delete the app bundle (which contains
+    // the daemon binary), so we block on the async call here. The wait is
+    // bounded; on XPC error the proxy's error handler signals immediately.
     {
-        //err msg
-        os_log_error(logHandle, "ERROR: daemon's XPC uninstall logic");
-        
-        //set flag
-        errors = YES;
-        
-        //but continue onwards
+        __block BOOL uninstalled = NO;
+        dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+        [xpcDaemonClient uninstall:^(BOOL result) {
+            uninstalled = result;
+            dispatch_semaphore_signal(sem);
+        }];
+        //wait up to 10s (daemon may need to flush rules to disk)
+        dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)));
+
+        if(YES != uninstalled)
+        {
+            //err msg
+            os_log_error(logHandle, "ERROR: daemon's XPC uninstall logic");
+
+            //set flag
+            errors = YES;
+
+            //but continue onwards
+        }
     }
     
     //first, remove login item

--- a/LuLu/App/PrefsWindowController.h
+++ b/LuLu/App/PrefsWindowController.h
@@ -92,6 +92,12 @@
 //selected profile
 @property(nonatomic, retain)NSString* selectedProfile;
 
+//current profile (cached; used by table-view delegate to avoid blocking XPC per row)
+@property(nonatomic, retain)NSString* currentProfile;
+
+//added view
+@property (nonatomic) BOOL viewWasAdded;
+
 //add profile sheet
 @property (strong) IBOutlet NSPanel* addProfileSheet;
 
@@ -139,9 +145,6 @@ enum profileViews
 
 //update window controller
 @property(nonatomic, retain)UpdateWindowController* updateWindowController;
-
-//added view
-@property (nonatomic) BOOL viewWasAdded;
 
 
 /* METHODS */

--- a/LuLu/App/PrefsWindowController.m
+++ b/LuLu/App/PrefsWindowController.m
@@ -74,12 +74,25 @@ extern XPCDaemonClient* xpcDaemonClient;
 // add it, and make it selected
 -(void)awakeFromNib
 {
-    //set subtitle
+    //set subtitle (async)
     [self setSubTitle];
-    
-    //get prefs
-    self.preferences = [xpcDaemonClient getPreferences];
-    
+
+    //get prefs (async)
+    // when loaded, cache + refresh current toolbar view if any was already selected
+    [xpcDaemonClient getPreferences:^(NSDictionary* prefs) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.preferences = prefs;
+
+            //if a toolbar item is already selected, re-trigger to populate it
+            NSToolbarItemIdentifier selectedID = self.toolbar.selectedItemIdentifier;
+            if(nil != selectedID) {
+                NSToolbarItem* item = [[self.toolbar items]
+                    filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"itemIdentifier == %@", selectedID]].firstObject;
+                if(nil != item) [self toolbarButtonHandler:item];
+            }
+        });
+    }];
+
     return;
 }
 
@@ -88,27 +101,33 @@ extern XPCDaemonClient* xpcDaemonClient;
 {
     //dbg msg
     os_log_debug(logHandle, "method '%s' invoked", __PRETTY_FUNCTION__);
-    
-    //current profile
-    NSString* currentProfile = [xpcDaemonClient getCurrentProfile];
-    
-    //have profile?
-    if(0 != currentProfile.length) {
-        
-        //add subtitle
-        if (@available(macOS 11.0, *)) {
-            self.window.subtitle = [NSString stringWithFormat:NSLocalizedString(@"Current Profile: %@",@"Current Profile: %@"), currentProfile];
-        }
-    }
-    //set to default
-    else
-    {
-        //set
-        if (@available(macOS 11.0, *)) {
-            self.window.subtitle = NSLocalizedString(@"Current Profile: Default",@"Current Profile: Default");
-        }
-    }
-    
+
+    //current profile (async)
+    [xpcDaemonClient getCurrentProfile:^(NSString* currentProfile) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            //cache for table-view delegate
+            self.currentProfile = currentProfile;
+
+            //have profile?
+            if(0 != currentProfile.length) {
+
+                //add subtitle
+                if (@available(macOS 11.0, *)) {
+                    self.window.subtitle = [NSString stringWithFormat:NSLocalizedString(@"Current Profile: %@",@"Current Profile: %@"), currentProfile];
+                }
+            }
+            //set to default
+            else
+            {
+                //set
+                if (@available(macOS 11.0, *)) {
+                    self.window.subtitle = NSLocalizedString(@"Current Profile: Default",@"Current Profile: Default");
+                }
+            }
+        });
+    }];
+
     return;
 }
 
@@ -249,22 +268,33 @@ extern XPCDaemonClient* xpcDaemonClient;
             
         //profiles
         case TOOLBAR_PROFILES:
-            
+
             //set view
             view = self.profilesView;
-            
-            //send XPC msg to daemon get profiles
-            self.profiles = [xpcDaemonClient getProfiles];
-            
-            //manually add default at start
-            [self.profiles insertObject:@"Default" atIndex:0];
-            
-            //dbg msg
-            os_log_debug(logHandle, "list of profiles: %{public}@", self.profiles);
-            
-            //reload table
-            [self.profilesTable reloadData];
-            
+
+            //send XPC msg to daemon to get profiles (async)
+            [xpcDaemonClient getProfiles:^(NSMutableArray* profilesFromDaemon) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+
+                    //fallback to empty array on XPC error
+                    self.profiles = (nil != profilesFromDaemon) ? profilesFromDaemon : [NSMutableArray array];
+
+                    //manually add default at start
+                    [self.profiles insertObject:@"Default" atIndex:0];
+
+                    //dbg msg
+                    os_log_debug(logHandle, "list of profiles: %{public}@", self.profiles);
+
+                    //also refresh the cached current profile (used by table-view delegate)
+                    [xpcDaemonClient getCurrentProfile:^(NSString* currentProfile) {
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            self.currentProfile = currentProfile;
+                            [self.profilesTable reloadData];
+                        });
+                    }];
+                });
+            }];
+
             break;
             
         //update
@@ -481,15 +511,19 @@ bail:
     //only process here if we're not in "add profile" mode
     if(YES != self.addProfileSheet.isVisible)
     {
-        //send XPC msg to daemon to update prefs
+        //send XPC msg to daemon to update prefs (async)
         // returns (all/latest) prefs, which is what we want
-        self.preferences = [xpcDaemonClient updatePreferences:updatedPreferences];
+        [xpcDaemonClient updatePreferences:updatedPreferences completion:^(NSDictionary* updatedFromDaemon) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if(nil != updatedFromDaemon) self.preferences = updatedFromDaemon;
 
-        //call back into app to process
-        // e.g. show/hide status bar icon, etc.
-        [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:self.preferences];
+                //call back into app to process
+                // e.g. show/hide status bar icon, etc.
+                [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:self.preferences];
+            });
+        }];
     }
-    
+
     return;
 }
 
@@ -520,24 +554,32 @@ bail:
         {
             //update ui
             self.allowList.stringValue = panel.URL.path;
-            
+
             //dbg msg
             os_log_debug(logHandle, "user selected allow list: %{public}@", self.allowList.stringValue);
-            
-            //send XPC msg to daemon to update prefs
-            self.preferences = [xpcDaemonClient updatePreferences:@{PREF_ALLOW_LIST:panel.URL.path}];
+
+            //send XPC msg to daemon to update prefs (async)
+            [xpcDaemonClient updatePreferences:@{PREF_ALLOW_LIST:panel.URL.path} completion:^(NSDictionary* updated) {
+                if(nil != updated) {
+                    dispatch_async(dispatch_get_main_queue(), ^{ self.preferences = updated; });
+                }
+            }];
         }
         //block list
         else if(sender == self.selectBlockListButton)
         {
             //update ui
             self.blockList.stringValue = panel.URL.path;
-            
+
             //dbg msg
             os_log_debug(logHandle, "user selected block list: %{public}@", self.blockList.stringValue);
-            
-            //send XPC msg to daemon to update prefs
-            self.preferences = [xpcDaemonClient updatePreferences:@{PREF_BLOCK_LIST:panel.URL.path}];
+
+            //send XPC msg to daemon to update prefs (async)
+            [xpcDaemonClient updatePreferences:@{PREF_BLOCK_LIST:panel.URL.path} completion:^(NSDictionary* updated) {
+                if(nil != updated) {
+                    dispatch_async(dispatch_get_main_queue(), ^{ self.preferences = updated; });
+                }
+            }];
         }
         //error
         else
@@ -555,11 +597,14 @@ bail:
 {
     //dbg msg
     os_log_debug(logHandle, "got 'update block list event' (value: %{public}@)", self.blockList.stringValue);
-    
-    //send XPC msg to daemon to update prefs
-    // returns (all/latest) prefs, which is what we want
-    self.preferences = [xpcDaemonClient updatePreferences:@{PREF_BLOCK_LIST:self.blockList.stringValue}];
-    
+
+    //send XPC msg to daemon to update prefs (async)
+    [xpcDaemonClient updatePreferences:@{PREF_BLOCK_LIST:self.blockList.stringValue} completion:^(NSDictionary* updated) {
+        if(nil != updated) {
+            dispatch_async(dispatch_get_main_queue(), ^{ self.preferences = updated; });
+        }
+    }];
+
     return;
 }
 
@@ -569,23 +614,28 @@ bail:
 {
     //dbg msg
     os_log_debug(logHandle, "%s invoked", __PRETTY_FUNCTION__);
-    
-    //grab (profile's) preferences
-    self.preferences = [xpcDaemonClient getPreferences];
-    
-    //(re)set subtitle
-    [self setSubTitle];
-    
-    //selected ID
-    NSToolbarItemIdentifier selectedID = self.toolbar.selectedItemIdentifier;
 
-    //selected item
-    NSToolbarItem* toolbarItem = [[self.toolbar items]
-        filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"itemIdentifier == %@", selectedID]].firstObject;
+    //grab (profile's) preferences (async)
+    [xpcDaemonClient getPreferences:^(NSDictionary* prefs) {
+        dispatch_async(dispatch_get_main_queue(), ^{
 
-    //trigger reload
-    [self toolbarButtonHandler:toolbarItem];
-    
+            if(nil != prefs) self.preferences = prefs;
+
+            //(re)set subtitle
+            [self setSubTitle];
+
+            //selected ID
+            NSToolbarItemIdentifier selectedID = self.toolbar.selectedItemIdentifier;
+
+            //selected item
+            NSToolbarItem* toolbarItem = [[self.toolbar items]
+                filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"itemIdentifier == %@", selectedID]].firstObject;
+
+            //trigger reload
+            if(nil != toolbarItem) [self toolbarButtonHandler:toolbarItem];
+        });
+    }];
+
     return;
 }
 
@@ -607,9 +657,10 @@ bail:
     //first column
     // check button if we're looking at the current profile
     if(YES == [tableColumn.identifier isEqualToString:@"Current"]) {
-        
-        //current profile
-        NSString* currentProfile = [xpcDaemonClient getCurrentProfile];
+
+        //current profile (cached — populated by toolbarButtonHandler / setSubTitle)
+        // avoids a blocking synchronous XPC call per table row
+        NSString* currentProfile = self.currentProfile;
         
         //select button
         NSButton* selectButton = (NSButton*)[cell viewWithTag:TABLE_ROW_SELECT_BTN_TAG];
@@ -735,20 +786,23 @@ bail:
     
     //dbg msg
     os_log_debug(logHandle, "user wants to change profile to '%{public}@'", profile ? profile : @"Default");
-    
-    //set profile via XPC
-    [xpcDaemonClient setProfile:profile];
-    
-    //tell app profiles changed
-    // will grab profile's preferences too
-    [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesChanged];
 
-    //also tell app preferences changed
-    [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:self.preferences];
-    
-    //show alert
-    showAlert(NSAlertStyleInformational, NSLocalizedString(@"Profile Switched", @"Profile Switched"), [NSString stringWithFormat:NSLocalizedString(@"Current profile is now: '%@'.", @"Current profile is now: '%@'."), nil != profile ? profile : NSLocalizedString(@"Default", @"Default")], @[NSLocalizedString(@"OK", @"OK")]);
-    
+    //set profile via XPC (async)
+    // wait for the daemon to confirm before refreshing the app
+    [xpcDaemonClient setProfile:profile completion:^(BOOL wasSet) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            //tell app profiles changed (will grab profile's preferences too)
+            [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesChanged];
+
+            //also tell app preferences changed
+            [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:self.preferences];
+
+            //show alert
+            showAlert(NSAlertStyleInformational, NSLocalizedString(@"Profile Switched", @"Profile Switched"), [NSString stringWithFormat:NSLocalizedString(@"Current profile is now: '%@'.", @"Current profile is now: '%@'."), nil != profile ? profile : NSLocalizedString(@"Default", @"Default")], @[NSLocalizedString(@"OK", @"OK")]);
+        });
+    }];
+
     return;
 }
 
@@ -810,25 +864,27 @@ bail:
             //add profile?
             // and handle UI refreshes, etc
             if (returnCode == NSModalResponseOK) {
-            
+
                 //dbg msg
                 os_log_debug(logHandle, "user wants to add profile '%{public}@'", self.profileName);
-                
-                //add profile via XPC
-                [xpcDaemonClient addProfile:self.profileName preferences:self.profilePreferences];
-                
-                //hide profile sheet
-                [self.addProfileSheet orderOut:self];
-                
-                //tell app profiles changed
-                // will grab profile's preferences too
-                [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesChanged];
-                
-                //tell app preferences changed
-                [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:self.preferences];
-                
-                //show alert
-                showAlert(NSAlertStyleInformational, NSLocalizedString(@"Added Profile", @"Added Profile"), [NSString stringWithFormat:NSLocalizedString(@"New profile '%@' saved and activated.", @"New profile '%@' saved and activated."), self.profileName], @[NSLocalizedString(@"OK", @"OK")]);
+
+                //add profile via XPC (async)
+                [xpcDaemonClient addProfile:self.profileName preferences:self.profilePreferences completion:^(BOOL wasAdded) {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+
+                        //hide profile sheet
+                        [self.addProfileSheet orderOut:self];
+
+                        //tell app profiles changed (will grab profile's preferences too)
+                        [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesChanged];
+
+                        //tell app preferences changed
+                        [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:self.preferences];
+
+                        //show alert
+                        showAlert(NSAlertStyleInformational, NSLocalizedString(@"Added Profile", @"Added Profile"), [NSString stringWithFormat:NSLocalizedString(@"New profile '%@' saved and activated.", @"New profile '%@' saved and activated."), self.profileName], @[NSLocalizedString(@"OK", @"OK")]);
+                    });
+                }];
             }
             
             //cancel
@@ -892,14 +948,18 @@ bail:
                 goto bail;
             }
             
-            //check against existing names
-            for(NSString *name in [xpcDaemonClient getProfiles])
+            //check against existing names (use cached profiles to avoid blocking XPC)
+            // self.profiles was populated when the user navigated to the Profiles tab.
+            // Filter out the synthetic "Default" entry (added in toolbarButtonHandler).
+            for(NSString *name in self.profiles)
             {
+                if(NSOrderedSame == [name caseInsensitiveCompare:NSLocalizedString(@"Default", @"Default")]) continue;
+
                 if(NSOrderedSame == [self.profileNameLabel.stringValue caseInsensitiveCompare:name])
                 {
                     //show alert
                     showAlert(NSAlertStyleInformational, NSLocalizedString(@"Invalid Profile Name", @"Invalid Profile Name"), [NSString stringWithFormat:NSLocalizedString(@"'%@' matches an existing profile name.", @"'%@' matches an existing profile name."), name], @[NSLocalizedString(@"OK", @"OK")]);
-                    
+
                     self.profileNameLabel.stringValue = @"";
                     goto bail;
                 }
@@ -1065,21 +1125,23 @@ bail:
         goto bail;
     }
     
-    //delete via XPC
-    [xpcDaemonClient deleteProfile:profile];
-    
-    //dbg msg
-    os_log_debug(logHandle, "deleted profile '%{public}@'", profile);
-    
-    //tell app profiles changed
-    // will grab profile's preferences too
-    [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesChanged];
-    
-    //tell app preferences (maybe) changed
-    [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:self.preferences];
-    
+    //delete via XPC (async)
+    [xpcDaemonClient deleteProfile:profile completion:^(BOOL wasDeleted) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            //dbg msg
+            os_log_debug(logHandle, "deleted profile '%{public}@' (result: %d)", profile, wasDeleted);
+
+            //tell app profiles changed (will grab profile's preferences too)
+            [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesChanged];
+
+            //tell app preferences (maybe) changed
+            [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:self.preferences];
+        });
+    }];
+
 bail:
-    
+
     return;
 }
 
@@ -1230,16 +1292,16 @@ bail:
         //disable allow list input
         self.allowList.enabled = NSControlStateValueOff;
         
-        //send XPC msg to daemon to update prefs
-        self.preferences = [xpcDaemonClient updatePreferences:@{PREF_USE_ALLOW_LIST:@0, PREF_ALLOW_LIST:@""}];
+        //send XPC msg to daemon to update prefs (async; window closing, no need to await)
+        [xpcDaemonClient updatePreferences:@{PREF_USE_ALLOW_LIST:@0, PREF_ALLOW_LIST:@""} completion:nil];
     }
-    
+
     //allow list changed? capture!
     // this logic is needed, as window can be closed when text field still has focus and 'end edit' won't have fired
     else if(YES != [self.preferences[PREF_ALLOW_LIST] isEqualToString:self.allowList.stringValue])
     {
-        //send XPC msg to daemon to update prefs
-        self.preferences = [xpcDaemonClient updatePreferences:@{PREF_ALLOW_LIST:self.allowList.stringValue}];
+        //send XPC msg to daemon to update prefs (async)
+        [xpcDaemonClient updatePreferences:@{PREF_ALLOW_LIST:self.allowList.stringValue} completion:nil];
     }
     
     //blank block list?
@@ -1258,17 +1320,16 @@ bail:
         //disable block list input
         self.blockList.enabled = NSControlStateValueOff;
         
-        //send XPC msg to daemon to update prefs
-        self.preferences = [xpcDaemonClient updatePreferences:@{PREF_USE_BLOCK_LIST:@0, PREF_BLOCK_LIST:@""}];
+        //send XPC msg to daemon to update prefs (async; window closing, no need to await)
+        [xpcDaemonClient updatePreferences:@{PREF_USE_BLOCK_LIST:@0, PREF_BLOCK_LIST:@""} completion:nil];
     }
-        
+
     //block list changed? capture!
     // this logic is needed, as window can be closed when text field still has focus and 'end edit' won't have fired
     else if(YES != [self.preferences[PREF_BLOCK_LIST] isEqualToString:self.blockList.stringValue])
     {
-        //send XPC msg to daemon to update prefs
-        // returns (all/latest) prefs, which is what we want
-        self.preferences = [xpcDaemonClient updatePreferences:@{PREF_BLOCK_LIST:self.blockList.stringValue}];
+        //send XPC msg to daemon to update prefs (async)
+        [xpcDaemonClient updatePreferences:@{PREF_BLOCK_LIST:self.blockList.stringValue} completion:nil];
     }
      
     //wait a bit, then set activation policy

--- a/LuLu/App/RulesMenuController.h
+++ b/LuLu/App/RulesMenuController.h
@@ -18,8 +18,13 @@
 -(void)addRule;
 -(void)showRules;
 -(void)exportRules;
--(BOOL)importRules;
--(NSInteger)cleanupRules;
+
+// async: completion is called on the main queue with BOOL success (or NO on cancel/error)
+-(void)importRulesWithCompletion:(void(^)(BOOL imported))completion;
+
+// async: completion is called on the main queue with number of deleted rules
+// (-1 on error, 0 if user cancelled)
+-(void)cleanupRulesWithCompletion:(void(^)(NSInteger deletedRules))completion;
 
 @end
 

--- a/LuLu/App/RulesMenuController.m
+++ b/LuLu/App/RulesMenuController.m
@@ -20,6 +20,12 @@ extern os_log_t logHandle;
 //xpc for daemon comms
 extern XPCDaemonClient* xpcDaemonClient;
 
+//class extension
+// declares helper methods used internally by async chains
+@interface RulesMenuController ()
+-(void)continueExportWithRules:(NSDictionary*)rules;
+@end
+
 @implementation RulesMenuController
 
 //show rules
@@ -46,27 +52,34 @@ extern XPCDaemonClient* xpcDaemonClient;
 // show panel then write out rules
 -(void)exportRules
 {
-    //count
-    __block NSUInteger count = 0;
-    
-    //rules
-    NSDictionary* rules = nil;
-    
-    //error
-    __block NSError* error = nil;
-    
-    //'browse' panel
-    NSSavePanel *panel = nil;
-    
     //dbg msg
     os_log_debug(logHandle, "exporting rules...");
-    
-    //get rules
-    rules = [xpcDaemonClient getRules];
-    
+
+    //get rules (async); the panel + export work runs once they arrive
+    [xpcDaemonClient getRules:^(NSDictionary* rulesFromDaemon) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self continueExportWithRules:(rulesFromDaemon ?: @{})];
+        });
+    }];
+
+    return;
+}
+
+//continue export, given fetched rules
+-(void)continueExportWithRules:(NSDictionary*)rules
+{
+    //count
+    __block NSUInteger count = 0;
+
+    //error
+    __block NSError* error = nil;
+
+    //'browse' panel
+    NSSavePanel *panel = nil;
+
     //dbg msg
     os_log_debug(logHandle, "received %lu rules from daemon", (unsigned long)rules.count);
-    
+
     //init panel
     panel = [NSSavePanel savePanel];
     
@@ -208,13 +221,10 @@ extern XPCDaemonClient* xpcDaemonClient;
     return;
 }
 
-//import rules
+//import rules (async)
 // show panel, read in rules, parse, send to daemon
--(BOOL)importRules
+-(void)importRulesWithCompletion:(void(^)(BOOL))completion
 {
-    //flag
-    BOOL imported = NO;
-    
     //flag
     __block BOOL userOnlyImport = YES;
     
@@ -370,72 +380,68 @@ extern XPCDaemonClient* xpcDaemonClient;
     
     //dbg msg
     os_log_debug(logHandle, "serialized (imported) rules");
-    
-    //send to daemon
-    if(YES != [xpcDaemonClient importRules:archivedRules userOnly:userOnlyImport])
-    {
-        //bail
-        goto bail;
-    }
-    
-    //happy
-    imported = YES;
-    
-    //tell (any) windows rules changed
-    [[NSNotificationCenter defaultCenter] postNotificationName:RULES_CHANGED object:nil userInfo:nil];
-    
-    //show alert
-    showAlert(NSAlertStyleInformational, [NSString stringWithFormat:NSLocalizedString(@"Imported %ld rules",@"Imported %ld rules"), count], nil, @[NSLocalizedString(@"OK", @"OK")]);
-    
+
+    //capture count for use inside async completion
+    NSUInteger finalCount = count;
+
+    //send to daemon (async)
+    [xpcDaemonClient importRules:archivedRules userOnly:userOnlyImport completion:^(BOOL imported) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if(imported)
+            {
+                //tell (any) windows rules changed
+                [[NSNotificationCenter defaultCenter] postNotificationName:RULES_CHANGED object:nil userInfo:nil];
+
+                //show alert
+                showAlert(NSAlertStyleInformational, [NSString stringWithFormat:NSLocalizedString(@"Imported %ld rules",@"Imported %ld rules"), finalCount], nil, @[NSLocalizedString(@"OK", @"OK")]);
+            }
+            if(completion) completion(imported);
+        });
+    }];
+
+    return;
+
 bail:
-    
-    return imported;
+
+    if(completion) completion(NO);
+    return;
 }
 
-//cleanup rules
--(NSInteger)cleanupRules
+//cleanup rules (async)
+-(void)cleanupRulesWithCompletion:(void(^)(NSInteger))completion
 {
-    //result
-    NSInteger cleanedUp = -1;
-    
     //dbg msg
     os_log_debug(logHandle, "method '%s' invoked", __PRETTY_FUNCTION__);
-    
+
     //first show rules
     [self showRules];
-    
-    //show alert
-    // if user cancels, just bail
+
+    //show alert — if user cancels, just bail
     if(NSAlertSecondButtonReturn == showAlert(NSAlertStyleInformational, NSLocalizedString(@"Clean up rules referencing deleted, expired, or terminated items?", @"Clean up rules referencing deleted, expired, or terminated items?"), nil, @[NSLocalizedString(@"OK",@"OK"), NSLocalizedString(@"Cancel",@"Cancel")]))
     {
         //dbg msg
         os_log_debug(logHandle, "user cancelled rule cleanup");
-        
+
         //not an error though
-        cleanedUp = 0;
-        
-        //bail
-        goto bail;
+        if(completion) completion(0);
+        return;
     }
-    
-    //call into daemon to cleanup
-    // returns number or deleted rules
-    cleanedUp = [xpcDaemonClient cleanupRules:YES];
-    if(cleanedUp < 0)
-    {
-        //bail
-        goto bail;
-    }
-    
-    //tell (any) windows rules changed
-    [[NSNotificationCenter defaultCenter] postNotificationName:RULES_CHANGED object:nil userInfo:nil];
-    
-    //share results w/ user
-    showAlert(NSAlertStyleInformational, [NSString stringWithFormat:NSLocalizedString(@"Cleaned up %ld rules",@"Cleaned up %ld rules"), cleanedUp], nil, @[NSLocalizedString(@"OK",@"OK")]);
-    
-bail:
-    
-    return cleanedUp;
+
+    //call into daemon to cleanup (async)
+    // returns number of deleted rules (-1 on XPC error)
+    [xpcDaemonClient cleanupRules:YES completion:^(NSInteger cleanedUp) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if(cleanedUp >= 0)
+            {
+                //tell (any) windows rules changed
+                [[NSNotificationCenter defaultCenter] postNotificationName:RULES_CHANGED object:nil userInfo:nil];
+
+                //share results w/ user
+                showAlert(NSAlertStyleInformational, [NSString stringWithFormat:NSLocalizedString(@"Cleaned up %ld rules",@"Cleaned up %ld rules"), cleanedUp], nil, @[NSLocalizedString(@"OK",@"OK")]);
+            }
+            if(completion) completion(cleanedUp);
+        });
+    }];
 }
 
 @end

--- a/LuLu/App/RulesWindowController.m
+++ b/LuLu/App/RulesWindowController.m
@@ -76,12 +76,12 @@ extern XPCDaemonClient* xpcDaemonClient;
     //dbg msg
     os_log_debug(logHandle, "method '%s' invoked", __PRETTY_FUNCTION__);
 
-    //set subtitle
+    //set subtitle (async)
     [self setSubTitle];
-    
-    //first cleanup any expired/temp rules
-    [xpcDaemonClient cleanupRules:NO];
-    
+
+    //first cleanup any expired/temp rules (async; result ignored)
+    [xpcDaemonClient cleanupRules:NO completion:nil];
+
     //then load rules
     [self loadRules:YES select:@0];
 
@@ -93,27 +93,30 @@ extern XPCDaemonClient* xpcDaemonClient;
 {
     //dbg msg
     os_log_debug(logHandle, "method '%s' invoked", __PRETTY_FUNCTION__);
-    
-    //current profile
-    NSString* currentProfile = [xpcDaemonClient getCurrentProfile];
-    
-    //have profile?
-    if(0 != currentProfile.length) {
-        
-        //add subtitle
-        if (@available(macOS 11.0, *)) {
-            self.window.subtitle = [NSString stringWithFormat:NSLocalizedString(@"Current Profile: %@",@"Current Profile: %@"), currentProfile];
-        }
-    }
-    //set to default
-    else
-    {
-        //set
-        if (@available(macOS 11.0, *)) {
-            self.window.subtitle = NSLocalizedString(@"Current Profile: Default",@"Current Profile: Default");
-        }
-    }
-    
+
+    //current profile (async)
+    [xpcDaemonClient getCurrentProfile:^(NSString* currentProfile) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            //have profile?
+            if(0 != currentProfile.length) {
+
+                //add subtitle
+                if (@available(macOS 11.0, *)) {
+                    self.window.subtitle = [NSString stringWithFormat:NSLocalizedString(@"Current Profile: %@",@"Current Profile: %@"), currentProfile];
+                }
+            }
+            //set to default
+            else
+            {
+                //set
+                if (@available(macOS 11.0, *)) {
+                    self.window.subtitle = NSLocalizedString(@"Current Profile: Default",@"Current Profile: Default");
+                }
+            }
+        });
+    }];
+
     return;
 }
 
@@ -182,83 +185,79 @@ extern XPCDaemonClient* xpcDaemonClient;
         [self.loadingRulesSpinner startAnimation:nil];
     }
     
-    //in background get rules
-    // ...then load rule table table
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
-    ^{
-        //current rules (from ext)
-        NSDictionary* currentRules = nil;
-        
-        //sorted keys
-        NSArray* sortedKeys = nil;
-        
-        //show overlay
-        if(YES == showOverlay)
-        {
-            //nap for UI (loading msg)
-            [NSThread sleepForTimeInterval:0.5f];
-        }
-        
-        //get rules
-        currentRules = [xpcDaemonClient getRules];
-        
+    //helper block: do sort + UI update (runs on whatever queue we hop it onto)
+    void (^processRules)(NSDictionary*) = ^(NSDictionary* currentRules) {
+
         //dbg msg
         os_log_debug(logHandle, "received %lu rules from daemon: %{public}@", (unsigned long)currentRules.count, currentRules.allKeys);
-        
+
         //sync rules
         @synchronized (self)
         {
             //alloc
             self.rules = [[OrderedDictionary alloc] init];
-        
+
             //dbg msg
             os_log_debug(logHandle, "sorting rules...");
-            
+
             //sort by (rule) name
-            sortedKeys = [currentRules keysSortedByValueUsingComparator:^NSComparisonResult(id _Nonnull obj1, id  _Nonnull obj2)
+            NSArray* sortedKeys = [currentRules keysSortedByValueUsingComparator:^NSComparisonResult(id _Nonnull obj1, id  _Nonnull obj2)
             {
                 //normal
                 if(YES == self.isAscending)
                 {
-                    //compare/return
                     return [((Rule*)[((NSDictionary*)obj1)[KEY_RULES] firstObject]).name compare:((Rule*)[((NSDictionary*)obj2)[KEY_RULES] firstObject]).name options:NSCaseInsensitiveSearch];
                 }
                 //reversed
                 else
                 {
-                    //compare/return
                     return [((Rule*)[((NSDictionary*)obj2)[KEY_RULES] firstObject]).name compare:((Rule*)[((NSDictionary*)obj1)[KEY_RULES] firstObject]).name options:NSCaseInsensitiveSearch];
                 }
             }];
-            
+
             //add sorted rules
             for(NSInteger i = 0; i<sortedKeys.count; i++)
             {
-                //add to ordered dictionary
                 [self.rules insertObject:currentRules[sortedKeys[i]] forKey:sortedKeys[i] atIndex:i];
             }
-            
+
         }//sync
-        
-        //show rules in UI
+
+        //show rules in UI on main queue
         dispatch_async(dispatch_get_main_queue(), ^{
-            
-            //show overlay
+
+            //hide overlay
             if(YES == showOverlay)
             {
-                //hide overlay
                 self.loadingRules.hidden = YES;
             }
-            
+
             //update ui
             [self update:row];
-            
+
             //set subtitle
             [self setSubTitle];
         });
+    };
 
-    });
-        
+    //fetch rules asynchronously from daemon (non-blocking; reply on XPC queue)
+    // optional "loading" nap is preserved by deferring the XPC fetch when overlay is shown
+    if(YES == showOverlay)
+    {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
+                       dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [xpcDaemonClient getRules:^(NSDictionary* currentRules) {
+                processRules(currentRules ?: @{});
+            }];
+        });
+    }
+    else
+    {
+        [xpcDaemonClient getRules:^(NSDictionary* currentRules) {
+            processRules(currentRules ?: @{});
+        }];
+    }
+
     return;
 }
 
@@ -477,29 +476,29 @@ bail:
 //show paths in sheet
 -(void)showItemPaths:(NSString*)itemKey
 {
-    //current rules (from ext)
-    NSDictionary* currentRules = nil;
-    
     //dbg msg
     os_log_debug(logHandle, "method '%s' invoked with %{public}@", __PRETTY_FUNCTION__, itemKey);
-    
+
     //alloc sheet
     self.itemPathsWindowController = [[ItemPathsWindowController alloc] initWithWindowNibName:@"ItemPaths"];
 
-    //get latest rules
-    currentRules = [xpcDaemonClient getRules];
-    
-    //set rules
-    self.itemPathsWindowController.item = currentRules[itemKey];
-    
-    //show it
-    [self.window beginSheet:self.itemPathsWindowController.window completionHandler:^(NSModalResponse returnCode) {
-        
-        //unset
-        self.itemPathsWindowController = nil;
-        
+    //get latest rules (async); show sheet once we have them
+    [xpcDaemonClient getRules:^(NSDictionary* currentRules) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+
+            //set rules
+            self.itemPathsWindowController.item = currentRules[itemKey];
+
+            //show it
+            [self.window beginSheet:self.itemPathsWindowController.window completionHandler:^(NSModalResponse returnCode) {
+
+                //unset
+                self.itemPathsWindowController = nil;
+
+            }];
+        });
     }];
-    
+
     return;
 }
 
@@ -1673,9 +1672,9 @@ bail:
 // set activation policy
 -(void)windowWillClose:(NSNotification *)notification
 {
-    //cleanup any expired/temp rules
-    [xpcDaemonClient cleanupRules:NO];
-    
+    //cleanup any expired/temp rules (async; result ignored)
+    [xpcDaemonClient cleanupRules:NO completion:nil];
+
     //wait a bit, then set activation policy
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
     ^{

--- a/LuLu/App/StatusBarItem.m
+++ b/LuLu/App/StatusBarItem.m
@@ -265,8 +265,8 @@ enum menuItems
             //set menu state
             [self setState];
         
-            //update prefs
-            [xpcDaemonClient updatePreferences:@{PREF_IS_DISABLED:[NSNumber numberWithBool:self.isDisabled]}];
+            //update prefs (async; result ignored)
+            [xpcDaemonClient updatePreferences:@{PREF_IS_DISABLED:[NSNumber numberWithBool:self.isDisabled]} completion:nil];
             
             //toggle network extension based on (new) state
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
@@ -308,36 +308,31 @@ enum menuItems
             
             break;
         
-        //rules: import
+        //rules: import (async)
         case rulesImport:
-            
-            //import
-            if(YES != [self.rulesMenuController importRules])
-            {
-                //show alert
-                showAlert(NSAlertStyleWarning, NSLocalizedString(@"ERROR: Failed to import rules", @"ERROR: Failed to import rules"), NSLocalizedString(@"See log for (more) details",@"See log for (more) details"), @[NSLocalizedString(@"OK", @"OK")]);
-                
-                //bail
-                goto bail;
-            }
-            
-            //then show rules
-            [self.rulesMenuController showRules];
-            
+
+            [self.rulesMenuController importRulesWithCompletion:^(BOOL imported) {
+                //already on main queue (callback dispatches there)
+                if(YES != imported)
+                {
+                    showAlert(NSAlertStyleWarning, NSLocalizedString(@"ERROR: Failed to import rules", @"ERROR: Failed to import rules"), NSLocalizedString(@"See log for (more) details",@"See log for (more) details"), @[NSLocalizedString(@"OK", @"OK")]);
+                    return;
+                }
+                //then show rules
+                [self.rulesMenuController showRules];
+            }];
+
             break;
-            
-        //rules: cleanup
+
+        //rules: cleanup (async)
         case rulesCleanup:
-            
-            //cleanup
-            if([self.rulesMenuController cleanupRules] < 0)
-            {
-                //show alert
-                showAlert(NSAlertStyleWarning, NSLocalizedString(@"ERROR: Failed to cleanup rules", @"ERROR: Failed to cleanup rules"), NSLocalizedString(@"See log for (more) details",@"See log for (more) details"), @[NSLocalizedString(@"OK",@"OK")]);
-                
-                //bail
-                goto bail;
-            }
+
+            [self.rulesMenuController cleanupRulesWithCompletion:^(NSInteger cleanedUp) {
+                if(cleanedUp < 0)
+                {
+                    showAlert(NSAlertStyleWarning, NSLocalizedString(@"ERROR: Failed to cleanup rules", @"ERROR: Failed to cleanup rules"), NSLocalizedString(@"See log for (more) details",@"See log for (more) details"), @[NSLocalizedString(@"OK",@"OK")]);
+                }
+            }];
             break;
         
         //profiles
@@ -407,115 +402,106 @@ bail:
 }
 
 //set current profile
+// async chain: fetch current profile, then fetch list, then rebuild menu on main queue
 -(void)setProfile
 {
-    //current
-    NSString* current = [xpcDaemonClient getCurrentProfile];
-    
-    //profiles
-    NSMutableArray* profiles = [xpcDaemonClient getProfiles];
-    
-    //grab menu
-    NSMenu* menu = [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesMenu];
-    
-    //set current profile
-    if(nil != current)
-    {
-        //set
-        [self.statusItem.menu itemWithTag:profile].title = [NSString stringWithFormat:NSLocalizedString(@"Profile: %@", @"Profile: %@"), current];
-    }
-    //otherwise (re)set to default
-    else
-    {
-        //set
-        [self.statusItem.menu itemWithTag:profile].title = NSLocalizedString(@"Profile: Default", @"Profile: Default");
-    }
-    
-    //reset profiles menu
-    [menu removeAllItems];
-    
-    //have profiles?
-    // add each name and enable 'Switch' menu item
-    if(0 != profiles.count)
-    {
-        //enable
-        [[((AppDelegate*)[[NSApplication sharedApplication] delegate]) profileSwitchMenuItem] setEnabled:YES];
-        
-        //add default first/top
-        [profiles insertObject:NSLocalizedString(@"Default", @"Default") atIndex:0];
-        
-        //add each name
-        for(NSString *name in profiles)
-        {
-            //menu item
-            NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:name action:@selector(switchToProfile:) keyEquivalent:@""];
-            
-            //target
-            item.target = self;
-            
-            //default to off
-            item.state = NSControlStateValueOff;
-            
-            //name
-            // though keep default 'nil'
-            if(NSOrderedSame != [name caseInsensitiveCompare:NSLocalizedString(@"Default", @"Default")])
-            {
-                //set
-                item.representedObject = name;
-            }
-            
-            //add
-            [menu addItem:item];
-            
-            //should select 'default' as current?
-            if( (nil == current) &&
-                (NSOrderedSame == [name caseInsensitiveCompare:NSLocalizedString(@"Default", @"Default")]) )
-            {
-                //set
-                item.state = NSControlStateValueOn;
-            }
-            
-            //should select other as current?
-            else if(YES == [item.title isEqualToString:current])
-            {
-                //set
-                item.state = NSControlStateValueOn;
-            }
-        }
-    }
-    //otherwise disable
-    else
-    {
-        //disable
-        [[((AppDelegate*)[[NSApplication sharedApplication] delegate]) profileSwitchMenuItem] setEnabled:NO];
-    }
-    
+    [xpcDaemonClient getCurrentProfile:^(NSString* current) {
+        [xpcDaemonClient getProfiles:^(NSMutableArray* profilesFromDaemon) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+
+                //grab menu
+                NSMenu* menu = [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesMenu];
+
+                //set current profile title
+                if(nil != current)
+                {
+                    [self.statusItem.menu itemWithTag:profile].title = [NSString stringWithFormat:NSLocalizedString(@"Profile: %@", @"Profile: %@"), current];
+                }
+                else
+                {
+                    [self.statusItem.menu itemWithTag:profile].title = NSLocalizedString(@"Profile: Default", @"Profile: Default");
+                }
+
+                //reset profiles menu
+                [menu removeAllItems];
+
+                //local mutable copy (fallback to empty)
+                NSMutableArray* profiles = profilesFromDaemon ?: [NSMutableArray array];
+
+                //have profiles?
+                if(0 != profiles.count)
+                {
+                    //enable
+                    [[((AppDelegate*)[[NSApplication sharedApplication] delegate]) profileSwitchMenuItem] setEnabled:YES];
+
+                    //add default first/top
+                    [profiles insertObject:NSLocalizedString(@"Default", @"Default") atIndex:0];
+
+                    //add each name
+                    for(NSString *name in profiles)
+                    {
+                        NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:name action:@selector(switchToProfile:) keyEquivalent:@""];
+                        item.target = self;
+                        item.state = NSControlStateValueOff;
+
+                        if(NSOrderedSame != [name caseInsensitiveCompare:NSLocalizedString(@"Default", @"Default")])
+                        {
+                            item.representedObject = name;
+                        }
+
+                        [menu addItem:item];
+
+                        if( (nil == current) &&
+                            (NSOrderedSame == [name caseInsensitiveCompare:NSLocalizedString(@"Default", @"Default")]) )
+                        {
+                            item.state = NSControlStateValueOn;
+                        }
+                        else if(YES == [item.title isEqualToString:current])
+                        {
+                            item.state = NSControlStateValueOn;
+                        }
+                    }
+                }
+                else
+                {
+                    //disable
+                    [[((AppDelegate*)[[NSApplication sharedApplication] delegate]) profileSwitchMenuItem] setEnabled:NO];
+                }
+            });
+        }];
+    }];
+
     return;
 }
 
 //switch profile
 - (void)switchToProfile:(NSMenuItem *)sender {
-    
+
     //grab profile
     NSString* profile = sender.representedObject;
-    
+
     //dbg msg
     os_log_debug(logHandle, "user wants to change profile to '%{public}@'", profile ? profile : @"Default");
-    
-    //set profile via XPC
-    // nil is ok, means (re)set to default
-    [xpcDaemonClient setProfile:profile];
-    
-    //tell app profiles changed
-    // will also update status menu
-    [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesChanged];
-    
-    //tell app preferences changed
-    [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:[xpcDaemonClient getPreferences]];
-    
-    //show alert
-    showAlert(NSAlertStyleInformational, NSLocalizedString(@"Profile Switched", @"Profile Switched"), [NSString stringWithFormat:NSLocalizedString(@"Current profile is now: '%@'.", @"Current profile is now: '%@'."), nil != profile ? profile : NSLocalizedString(@"Default", @"Default")], @[NSLocalizedString(@"OK", @"OK")]);
-    
+
+    //set profile via XPC (async) — nil is ok, means (re)set to default
+    [xpcDaemonClient setProfile:profile completion:^(BOOL wasSet) {
+
+        //then fetch the (new) preferences
+        [xpcDaemonClient getPreferences:^(NSDictionary* prefs) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+
+                //tell app profiles changed (will also update status menu)
+                [((AppDelegate*)[[NSApplication sharedApplication] delegate]) profilesChanged];
+
+                //tell app preferences changed
+                [((AppDelegate*)[[NSApplication sharedApplication] delegate]) preferencesChanged:prefs];
+
+                //show alert
+                showAlert(NSAlertStyleInformational, NSLocalizedString(@"Profile Switched", @"Profile Switched"), [NSString stringWithFormat:NSLocalizedString(@"Current profile is now: '%@'.", @"Current profile is now: '%@'."), nil != profile ? profile : NSLocalizedString(@"Default", @"Default")], @[NSLocalizedString(@"OK", @"OK")]);
+            });
+        }];
+    }];
+
     return;
 }
 

--- a/LuLu/App/XPCDaemonClient.h
+++ b/LuLu/App/XPCDaemonClient.h
@@ -13,55 +13,61 @@
 
 @interface XPCDaemonClient : NSObject
 {
-    
+
 }
 
 //xpc connection to daemon
 @property (atomic, strong, readwrite)NSXPCConnection* daemon;
 
+//
+// NOTE: All methods are now asynchronous and non-blocking.
+// Callers MUST dispatch any UI work performed inside the completion block
+// back to the main queue (dispatch_get_main_queue()).
+// Completion blocks are invoked on an arbitrary XPC queue.
+//
+
 //get preferences
-// note: synchronous
--(NSDictionary*)getPreferences;
+-(void)getPreferences:(void (^)(NSDictionary* _Nullable preferences))completion;
 
 //update (save) preferences
-// note: synchronous, as then returns latest preferences
--(NSDictionary*)updatePreferences:(NSDictionary*)preferences;
+// note: returns merged preferences (from daemon) via the completion block
+-(void)updatePreferences:(NSDictionary*)preferences completion:(void (^)(NSDictionary* _Nullable updatedPreferences))completion;
 
 //get rules
-// note: synchronous
--(NSDictionary*)getRules;
+-(void)getRules:(void (^)(NSDictionary* _Nullable rules))completion;
 
-//add rule
+//add rule (fire-and-forget)
 -(void)addRule:(NSDictionary*)info;
 
-//disable (or re-enable) rule
+//disable (or re-enable) rule (fire-and-forget)
 -(void)toggleRule:(NSString*)key rule:(NSString*)uuid state:(NSNumber*)state;
 
-//delete rule
+//delete rule (fire-and-forget)
 -(void)deleteRule:(NSString*)key rule:(NSString*)uuid;
 
 //import rules
--(BOOL)importRules:(NSData*)newRules userOnly:(BOOL)userOnly;
+-(void)importRules:(NSData*)newRules userOnly:(BOOL)userOnly completion:(void (^)(BOOL imported))completion;
 
 //cleanup rules
--(NSInteger)cleanupRules:(BOOL)full;
+// note: NSInteger result is -1 on error (e.g. XPC failure)
+-(void)cleanupRules:(BOOL)full completion:(void (^)(NSInteger deletedRules))completion;
 
 //get current profile
--(NSString*)getCurrentProfile;
+-(void)getCurrentProfile:(void (^)(NSString* _Nullable currentProfile))completion;
 
 //get list of profiles
--(NSMutableArray*)getProfiles;
+-(void)getProfiles:(void (^)(NSMutableArray* _Nullable profiles))completion;
 
 //set profile
--(BOOL)setProfile:(NSString*)name;
+-(void)setProfile:(NSString*)name completion:(void (^)(BOOL wasSet))completion;
 
 //add profile
--(BOOL)addProfile:(NSString*)name preferences:(NSDictionary*)preferences;
+-(void)addProfile:(NSString*)name preferences:(NSDictionary*)preferences completion:(void (^)(BOOL wasAdded))completion;
 
 //delete profile
--(BOOL)deleteProfile:(NSString*)name;
+-(void)deleteProfile:(NSString*)name completion:(void (^)(BOOL wasDeleted))completion;
 
 //uninstall
--(BOOL)uninstall;
+-(void)uninstall:(void (^)(BOOL wasUninstalled))completion;
 
 @end

--- a/LuLu/App/XPCDaemonClient.m
+++ b/LuLu/App/XPCDaemonClient.m
@@ -1,7 +1,7 @@
 //
 //  file: XPCDaemonClient.m
 //  project: lulu (shared)
-//  description: talk to daemon via XPC (header)
+//  description: talk to daemon via XPC (asynchronous, non-blocking)
 //
 //  created by Patrick Wardle
 //  copyright (c) 2017 Objective-See. All rights reserved.
@@ -36,391 +36,323 @@ extern NSMutableDictionary* alerts;
     {
         //alloc/init
         daemon = [[NSXPCConnection alloc] initWithMachServiceName:DAEMON_MACH_SERVICE options:0];
-    
+
         //set remote object interface
         self.daemon.remoteObjectInterface = [NSXPCInterface interfaceWithProtocol:@protocol(XPCDaemonProtocol)];
-        
+
         //set exported object interface (protocol)
         self.daemon.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(XPCUserProtocol)];
-        
+
         //set exported object
         // this will allow daemon to invoke user methods!
         self.daemon.exportedObject = [[XPCUser alloc] init];
-    
+
         //resume
         [self.daemon resume];
     }
-    
+
     return self;
 }
 
-//get preferences
-// note: synchronous, will block until daemon responds
--(NSDictionary*)getPreferences
+#pragma mark - Preferences
+
+//get preferences (async)
+-(void)getPreferences:(void (^)(NSDictionary* _Nullable))completion
 {
-    //preferences
-    __block NSDictionary* preferences = nil;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s'", __PRETTY_FUNCTION__);
-    
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError * proxyError)
-    {
-          //err msg
-          os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
 
-   }] getPreferences:^(NSDictionary* preferencesFromDaemon)
-   {
-       //dbg msg
-       os_log_debug(logHandle, "got preferences: %{public}@", preferencesFromDaemon);
-       
-       //save
-       preferences = preferencesFromDaemon;
-       
-   }];
-    
-    return preferences;
-}
-
-//update (save) preferences
-// note: will merge into current ones
--(NSDictionary*)updatePreferences:(NSDictionary*)preferences
-{
-    //updated preferences (from daemon)
-    __block NSDictionary* updatedPreferences = nil;
-    
-    //dbg msg
-    os_log_debug(logHandle, "invoking daemon XPC method, '%s'", __PRETTY_FUNCTION__);
-    
-    //update prefs
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError * proxyError)
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-          
-    }] updatePreferences:preferences reply:^(NSDictionary* preferences)
+
+        //fail-safe: still invoke completion so callers don't hang
+        if(completion) completion(nil);
+
+    }] getPreferences:^(NSDictionary* preferencesFromDaemon)
     {
         //dbg msg
-        os_log_debug(logHandle, "got preferences: %{public}@", preferences);
-        
-        //save
-        updatedPreferences = preferences;
-        
+        os_log_debug(logHandle, "got preferences: %{public}@", preferencesFromDaemon);
+
+        if(completion) completion(preferencesFromDaemon);
     }];
-    
-    return updatedPreferences;
 }
 
-//get rules
-// note: synchronous, will block until daemon responds
--(NSDictionary*)getRules
+//update (save) preferences (async)
+// note: daemon merges into current ones, returns merged result
+-(void)updatePreferences:(NSDictionary*)preferences completion:(void (^)(NSDictionary* _Nullable))completion
 {
-    //rules
-    __block NSMutableDictionary* rules = nil;
-    
-    //error
-    __block NSError* error = nil;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s'", __PRETTY_FUNCTION__);
-    
-    //make XPC request to get rules
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError * proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-        
+
+        if(completion) completion(nil);
+
+    }] updatePreferences:preferences reply:^(NSDictionary* updatedPreferences)
+    {
+        //dbg msg
+        os_log_debug(logHandle, "got updated preferences: %{public}@", updatedPreferences);
+
+        if(completion) completion(updatedPreferences);
+    }];
+}
+
+#pragma mark - Rules
+
+//get rules (async)
+-(void)getRules:(void (^)(NSDictionary* _Nullable))completion
+{
+    //dbg msg
+    os_log_debug(logHandle, "invoking daemon XPC method, '%s'", __PRETTY_FUNCTION__);
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
+    {
+        //err msg
+        os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
+
+        if(completion) completion(nil);
+
     }] getRules:^(NSData* archivedRules)
     {
+        NSError* error = nil;
+
         //unarchive
-        rules = [NSKeyedUnarchiver unarchivedObjectOfClasses:
+        NSMutableDictionary* rules = [NSKeyedUnarchiver unarchivedObjectOfClasses:
                  [NSSet setWithArray: @[[NSMutableDictionary class], [NSMutableArray class], [NSString class], [NSNumber class], [NSMutableSet class], [NSDate class], [Rule class]]] fromData:archivedRules error:&error];
-        
+
         if(nil != error)
         {
             //err msg
             os_log_error(logHandle, "ERROR: failed to unarchive rules: %{public}@", error);
         }
-    
+
+        if(completion) completion(rules);
     }];
-    
-    return rules;
 }
 
-//add rule
+//add rule (fire-and-forget)
 -(void)addRule:(NSDictionary*)info
 {
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s' with info: %{public}@", __PRETTY_FUNCTION__, info);
-    
-    //make XPC request to add rule
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError * proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-        
+
     }] addRule:info];
-    
-    return;
 }
 
-//disable (or re-enable) rule
+//disable (or re-enable) rule (fire-and-forget)
 -(void)toggleRule:(NSString*)key rule:(NSString*)uuid state:(NSNumber*)state
 {
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s' with key: %{public}@, rule id: %{public}@", __PRETTY_FUNCTION__, key, uuid);
-    
-    //disable rule
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError * proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-        
+
     }] toggleRule:key rule:uuid state:state];
-    
-    return;
 }
 
-//delete rule
+//delete rule (fire-and-forget)
 -(void)deleteRule:(NSString*)key rule:(NSString*)uuid
 {
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s' with key: %{public}@, rule id: %{public}@", __PRETTY_FUNCTION__, key, uuid);
-    
-    //delete rule
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError * proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-        
+
     }] deleteRule:key rule:uuid];
-    
-    return;
 }
 
-//cleanup rules
--(NSInteger)cleanupRules:(BOOL)full
+//cleanup rules (async)
+-(void)cleanupRules:(BOOL)full completion:(void (^)(NSInteger))completion
 {
-    //result
-    __block NSInteger deletedRules = -1;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s'", __PRETTY_FUNCTION__);
-    
-    //import rules
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError * proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-          
+
+        //signal failure to caller
+        if(completion) completion(-1);
+
     }] cleanupRules:full reply:^(NSInteger result)
     {
         //dbg msg
-        os_log_debug(logHandle, "daemon XPC method, '%s', done! (returned %ld)", __PRETTY_FUNCTION__, (long)deletedRules);
-         
-        //save result
-        deletedRules = result;
-         
+        os_log_debug(logHandle, "daemon XPC method, '%s', done! (returned %ld)", __PRETTY_FUNCTION__, (long)result);
+
+        if(completion) completion(result);
     }];
-    
-    return deletedRules;
 }
 
-//update (save) preferences
--(BOOL)importRules:(NSData*)newRules userOnly:(BOOL)userOnly
+//import rules (async)
+-(void)importRules:(NSData*)newRules userOnly:(BOOL)userOnly completion:(void (^)(BOOL))completion
 {
-    //flag
-    __block BOOL wasImported = NO;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s'", __PRETTY_FUNCTION__);
-    
-    //import rules
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError * proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-          
-    }] importRules:newRules userOnly:(BOOL)userOnly result:^(BOOL result)
+
+        if(completion) completion(NO);
+
+    }] importRules:newRules userOnly:userOnly result:^(BOOL result)
     {
         //dbg msg
-        os_log_debug(logHandle, "daemon XPC method, '%s', done!", __PRETTY_FUNCTION__);
-         
-        //set flag
-        wasImported = YES;
-         
+        os_log_debug(logHandle, "daemon XPC method, '%s', done! (result: %d)", __PRETTY_FUNCTION__, result);
+
+        if(completion) completion(result);
     }];
-    
-    return wasImported;
 }
 
-//get current profile
--(NSString*)getCurrentProfile
+#pragma mark - Profiles
+
+//get current profile (async)
+-(void)getCurrentProfile:(void (^)(NSString* _Nullable))completion
 {
-    //rules
-    __block NSString* currentProfile = nil;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s'", __PRETTY_FUNCTION__);
-    
-    //make XPC request to get profiles
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError* proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-        
-    }] getCurrentProfile:^(NSString* currrentProfileFromDaemon)
+
+        if(completion) completion(nil);
+
+    }] getCurrentProfile:^(NSString* currentProfileFromDaemon)
     {
         //dbg msg
-        os_log_debug(logHandle, "current profile from daemon: '%{public}@'", currrentProfileFromDaemon);
-        
-        //save
-        currentProfile = currrentProfileFromDaemon;
-    
+        os_log_debug(logHandle, "current profile from daemon: '%{public}@'", currentProfileFromDaemon);
+
+        if(completion) completion(currentProfileFromDaemon);
     }];
-    
-    return currentProfile;
 }
 
-//get list of profiles
--(NSMutableArray*)getProfiles
+//get list of profiles (async)
+-(void)getProfiles:(void (^)(NSMutableArray* _Nullable))completion
 {
-    //rules
-    __block NSMutableArray* profiles = nil;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s'", __PRETTY_FUNCTION__);
-    
-    //make XPC request to get profiles
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError* proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-        
+
+        if(completion) completion(nil);
+
     }] getProfiles:^(NSArray* profilesFromDaemon)
     {
-        //save
-        profiles = [profilesFromDaemon mutableCopy];
-    
+        if(completion) completion([profilesFromDaemon mutableCopy]);
     }];
-    
-    return profiles;
 }
 
-//set profile
--(BOOL)setProfile:(NSString*)name
+//set profile (async)
+-(void)setProfile:(NSString*)name completion:(void (^)(BOOL))completion
 {
-    //flag
-    __block BOOL wasSet = NO;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s' with name: %{public}@", __PRETTY_FUNCTION__, name);
-    
-    //send XPC message to set profile
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError* proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-        
+
+        if(completion) completion(NO);
+
     }] setProfile:name reply:^(BOOL reply)
     {
         //dbg msg
-        os_log_debug(logHandle, "daemon XPC method, '%s', done!", __PRETTY_FUNCTION__);
-          
-        //set flag
-        wasSet = reply;
-          
+        os_log_debug(logHandle, "daemon XPC method, '%s', done! (result: %d)", __PRETTY_FUNCTION__, reply);
+
+        if(completion) completion(reply);
     }];
-    
-    return wasSet;
 }
 
-//add profile
--(BOOL)addProfile:(NSString*)name preferences:(NSDictionary*)preferences
+//add profile (async)
+-(void)addProfile:(NSString*)name preferences:(NSDictionary*)preferences completion:(void (^)(BOOL))completion
 {
-    //flag
-    __block BOOL wasAdded = NO;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s' with %{public}@", __PRETTY_FUNCTION__, name);
-    
-    //make XPC request to add profile
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError* proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-        
+
+        if(completion) completion(NO);
+
     }] addProfile:name preferences:preferences reply:^(BOOL reply)
     {
         //dbg msg
-        os_log_debug(logHandle, "daemon XPC method, '%s', done!", __PRETTY_FUNCTION__);
-          
-        //set flag
-        wasAdded = reply;
-          
+        os_log_debug(logHandle, "daemon XPC method, '%s', done! (result: %d)", __PRETTY_FUNCTION__, reply);
+
+        if(completion) completion(reply);
     }];
-    
-    return wasAdded;
 }
 
-//delete profile
--(BOOL)deleteProfile:(NSString*)name
+//delete profile (async)
+-(void)deleteProfile:(NSString*)name completion:(void (^)(BOOL))completion
 {
-    //flag
-    __block BOOL wasDeleted = NO;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s' with name: %{public}@", __PRETTY_FUNCTION__, name);
-    
-    //send XPC message to delete profile
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError* proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-        
+
+        if(completion) completion(NO);
+
     }] deleteProfile:name reply:^(BOOL reply)
     {
         //dbg msg
-        os_log_debug(logHandle, "daemon XPC method, '%s', done!", __PRETTY_FUNCTION__);
-         
-        //set flag
-        wasDeleted = reply;
-         
+        os_log_debug(logHandle, "daemon XPC method, '%s', done! (result: %d)", __PRETTY_FUNCTION__, reply);
+
+        if(completion) completion(reply);
     }];
-    
-    //dbg msg
-    os_log_debug(logHandle, "daemon XPC method, '%s' with name: %{public}@ returned", __PRETTY_FUNCTION__, name);
-    
-    return wasDeleted;
 }
 
-//uninstall
--(BOOL)uninstall
+#pragma mark - Uninstall
+
+//uninstall (async)
+-(void)uninstall:(void (^)(BOOL))completion
 {
-    //flag
-    __block BOOL uninstalled = NO;
-    
     //dbg msg
     os_log_debug(logHandle, "invoking daemon XPC method, '%s'", __PRETTY_FUNCTION__);
-    
-    //uninstall
-    [[self.daemon synchronousRemoteObjectProxyWithErrorHandler:^(NSError * proxyError)
+
+    [[self.daemon remoteObjectProxyWithErrorHandler:^(NSError * proxyError)
     {
         //err msg
         os_log_error(logHandle, "ERROR: failed to execute daemon XPC method '%s' (error: %{public}@)", __PRETTY_FUNCTION__, proxyError);
-          
+
+        if(completion) completion(NO);
+
     }] uninstall:^(BOOL result)
     {
         //dbg msg
-        os_log_debug(logHandle, "daemon XPC method, '%s', done!", __PRETTY_FUNCTION__);
-        
-        //set flag
-        uninstalled = result;
-        
-    }];
-    
-    return uninstalled;
+        os_log_debug(logHandle, "daemon XPC method, '%s', done! (result: %d)", __PRETTY_FUNCTION__, result);
 
+        if(completion) completion(result);
+    }];
 }
 
 @end


### PR DESCRIPTION
## Problem

Every call from the App to the daemon was made through `synchronousRemoteObjectProxyWithErrorHandler:`, which **blocks the calling thread until the daemon replies**.  Because most of these calls originated on the main thread (menu actions, window lifecycle hooks, table-view delegates, preference toggles), any latency on the XPC channel — daemon busy, system under load, brief IPC hiccup — would **freeze the entire UI** for the duration of the wait.  This included interactive operations that users trigger deliberately (opening the Rules window, switching profiles, importing rules, exporting rules, toggling the firewall), all of which silently stalled the run loop.

The 14 methods in `XPCDaemonClient` that used synchronous proxies: 
getPreferences, updatePreferences, getRules, importRules: userOnly, cleanupRules, getCurrentProfile, getProfiles, setProfile, addProfile:preferences, deleteProfile, uninstall

## Solution

Replace every synchronous proxy call with `remoteObjectProxyWithErrorHandler:` and propagate results through **completion blocks**.  Callers perform any subsequent UI work via `dispatch_async(dispatch_get_main_queue(), …)` inside those blocks.

The three purely fire-and-forget methods (`addRule:`, `toggleRule:uuid:state:`, `deleteRule:uuid:`) already used void returns and required no change.
