### PR TITLE
Fix Spanish enable and disable menu translations

### DIFF
--- a/LuLu/App/mul.lproj/MainMenu.xcstrings
+++ b/LuLu/App/mul.lproj/MainMenu.xcstrings
@@ -1102,7 +1102,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deshabilitar"
+            "value" : "Desactivar"
           }
         },
         "fr" : {
@@ -2026,7 +2026,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LULU: habilitado"
+            "value" : "LULU: activado"
           }
         },
         "fr" : {

--- a/LuLu/Shared/Localizable.xcstrings
+++ b/LuLu/Shared/Localizable.xcstrings
@@ -4728,7 +4728,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Desactivado"
+            "value" : "Desactivar"
           }
         },
         "fr" : {
@@ -5035,7 +5035,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Activado"
+            "value" : "Activar"
           }
         },
         "fr" : {


### PR DESCRIPTION
The Spanish localization used inconsistent translations for the same enable/disable menu commands in XIB-extracted strings and runtime strings.

Besides, "Activado" and "Desactivado" describe states ("enabled"/"disabled"), not the action performed by the menu command. Use the infinitive verbs "Activar" and "Desactivar" for the command labels.