### PR TITLE
Improving readability of user defined rules

### DIFF
--- a/LuLu/App/AddRuleWindowController.m
+++ b/LuLu/App/AddRuleWindowController.m
@@ -11,8 +11,6 @@
 #import "utilities.h"
 #import "AddRuleWindowController.h"
 
-#import <arpa/inet.h>
-
 /* GLOBALS */
 
 //log handle
@@ -252,61 +250,6 @@ bail:
     return [NSString stringWithFormat:@"^%@$", [escaped componentsJoinedByString:@".*"]];
 }
 
-//is string an IP address literal?
--(BOOL)isIPAddressLiteral:(NSString*)input
-{
-    //address bytes
-    uint8_t address[16] = {0};
-    
-    //empty?
-    if(0 == input.length) {
-        return NO;
-    }
-    
-    //IPv4/IPv6?
-    return ( (1 == inet_pton(AF_INET, input.UTF8String, address)) ||
-             (1 == inet_pton(AF_INET6, input.UTF8String, address)) );
-}
-
-//does input look like an intended IP range?
-// used after range parsing fails, to avoid treating malformed ranges as exact hostnames
--(BOOL)looksLikeIPRange:(NSString*)input
-{
-    //dash
-    NSRange dash = {0};
-    
-    //sides
-    NSString* left = nil;
-    NSString* right = nil;
-    
-    //whitespace
-    NSCharacterSet* whitespace = nil;
-    
-    //no dash?
-    dash = [input rangeOfString:@"-"];
-    if(NSNotFound == dash.location) {
-        return NO;
-    }
-    
-    //init
-    whitespace = NSCharacterSet.whitespaceCharacterSet;
-    
-    //split
-    left = [[input substringToIndex:dash.location] stringByTrimmingCharactersInSet:whitespace];
-    right = [[input substringFromIndex:(dash.location + 1)] stringByTrimmingCharactersInSet:whitespace];
-    
-    //empty side?
-    if( (0 == left.length) ||
-        (0 == right.length) )
-    {
-        return NO;
-    }
-    
-    //range-like if either side is already a valid IP literal
-    return ( (YES == [self isIPAddressLiteral:left]) ||
-             (YES == [self isIPAddressLiteral:right]) );
-}
-
 //'add' button handler
 // close sheet, returning NSModalResponseOK
 -(IBAction)addButtonHandler:(id)sender
@@ -484,7 +427,7 @@ bail:
         }
         //looks like an IP range, but didn't parse?
         // reject obvious range input rather than storing a dead exact-match rule
-        else if(YES == [self looksLikeIPRange:endpointAddr])
+        else if(YES == looksLikeIPAddressRange(endpointAddr))
         {
             //show alert
             showAlert(NSAlertStyleWarning, NSLocalizedString(@"ERROR: invalid IP range", @"ERROR: invalid IP range"), [NSString stringWithFormat:NSLocalizedString(@"%@ is not a valid IP range (e.g. 1.2.3.4 - 23.3.4.6)", @"%@ is not a valid IP range (e.g. 1.2.3.4 - 23.3.4.6)"), endpointAddr], @[NSLocalizedString(@"OK", @"OK")]);

--- a/LuLu/App/AddRuleWindowController.m
+++ b/LuLu/App/AddRuleWindowController.m
@@ -11,6 +11,8 @@
 #import "utilities.h"
 #import "AddRuleWindowController.h"
 
+#import <arpa/inet.h>
+
 /* GLOBALS */
 
 //log handle
@@ -44,11 +46,12 @@ extern os_log_t logHandle;
         self.path.stringValue = self.rule.path;
         
         //endpoint addr
-        self.endpointAddr.stringValue = self.rule.endpointAddr;
+        self.endpointAddr.stringValue = (0 != self.rule.endpointAddrDisplay.length) ? self.rule.endpointAddrDisplay : self.rule.endpointAddr;
         
         //regex button
-        // note: cidr/glob rules show their string with the box unchecked
-        if(EndpointTypeRegex == self.rule.isEndpointAddrRegex)
+        // note: generated wildcard regex rules show their friendly string with the box unchecked
+        if( (EndpointTypeRegex == self.rule.isEndpointAddrRegex) &&
+            (EndpointInputKindGlob != self.rule.endpointInputKind.integerValue) )
         {
             //on
             self.isEndpointAddrRegex.state = NSControlStateValueOn;
@@ -249,6 +252,61 @@ bail:
     return [NSString stringWithFormat:@"^%@$", [escaped componentsJoinedByString:@".*"]];
 }
 
+//is string an IP address literal?
+-(BOOL)isIPAddressLiteral:(NSString*)input
+{
+    //address bytes
+    uint8_t address[16] = {0};
+    
+    //empty?
+    if(0 == input.length) {
+        return NO;
+    }
+    
+    //IPv4/IPv6?
+    return ( (1 == inet_pton(AF_INET, input.UTF8String, address)) ||
+             (1 == inet_pton(AF_INET6, input.UTF8String, address)) );
+}
+
+//does input look like an intended IP range?
+// used after range parsing fails, to avoid treating malformed ranges as exact hostnames
+-(BOOL)looksLikeIPRange:(NSString*)input
+{
+    //dash
+    NSRange dash = {0};
+    
+    //sides
+    NSString* left = nil;
+    NSString* right = nil;
+    
+    //whitespace
+    NSCharacterSet* whitespace = nil;
+    
+    //no dash?
+    dash = [input rangeOfString:@"-"];
+    if(NSNotFound == dash.location) {
+        return NO;
+    }
+    
+    //init
+    whitespace = NSCharacterSet.whitespaceCharacterSet;
+    
+    //split
+    left = [[input substringToIndex:dash.location] stringByTrimmingCharactersInSet:whitespace];
+    right = [[input substringFromIndex:(dash.location + 1)] stringByTrimmingCharactersInSet:whitespace];
+    
+    //empty side?
+    if( (0 == left.length) ||
+        (0 == right.length) )
+    {
+        return NO;
+    }
+    
+    //range-like if either side is already a valid IP literal
+    return ( (YES == [self isIPAddressLiteral:left]) ||
+             (YES == [self isIPAddressLiteral:right]) );
+}
+
 //'add' button handler
 // close sheet, returning NSModalResponseOK
 -(IBAction)addButtonHandler:(id)sender
@@ -267,6 +325,18 @@ bail:
     
     //(remote) endpoint addr
     NSString* endpointAddr = nil;
+    
+    //(remote) endpoint addr, as entered/displayed
+    NSString* endpointAddrDisplay = nil;
+    
+    //(remote) endpoint technical matcher
+    NSString* endpointAddrMatcher = nil;
+    
+    //endpoint input kind
+    NSNumber* endpointInputKind = nil;
+    
+    //normalized endpoint input
+    NSString* endpointInputNormalized = nil;
     
     //endpoint addr match type {exact, regex, cidr}
     NSNumber* endpointAddrRegex = nil;
@@ -331,7 +401,11 @@ bail:
     
     //endpoint addr
     // or '*' if blank
-    endpointAddr = (0 != self.endpointAddr.stringValue.length) ? self.endpointAddr.stringValue : VALUE_ANY;
+    endpointAddrDisplay = (0 != self.endpointAddr.stringValue.length) ? self.endpointAddr.stringValue : VALUE_ANY;
+    endpointAddr = endpointAddrDisplay;
+    endpointAddrMatcher = NSLocalizedString(@"Exact", @"Exact");
+    endpointInputKind = @(EndpointInputKindExact);
+    endpointInputNormalized = endpointAddrDisplay;
     
     //determine endpoint addr match type {exact, regex, cidr}
     EndpointType endpointType = EndpointTypeExact;
@@ -342,6 +416,8 @@ bail:
     {
         //regex
         endpointType = EndpointTypeRegex;
+        endpointAddrMatcher = [NSString stringWithFormat:NSLocalizedString(@"Regex: %@", @"Regex: %@"), endpointAddr];
+        endpointInputKind = @(EndpointInputKindRegex);
 
         //validate
         if(nil == [NSRegularExpression regularExpressionWithPattern:endpointAddr options:0 error:&error])
@@ -365,6 +441,8 @@ bail:
 
             //convert glob -> anchored regex
             endpointAddr = [self regexFromGlob:endpointAddr];
+            endpointAddrMatcher = [NSString stringWithFormat:NSLocalizedString(@"Generated regex: %@", @"Generated regex: %@"), endpointAddr];
+            endpointInputKind = @(EndpointInputKindGlob);
 
             //regex
             endpointType = EndpointTypeRegex;
@@ -381,6 +459,18 @@ bail:
 
             //cidr
             endpointType = EndpointTypeCIDR;
+            
+            //matcher metadata
+            if(NSNotFound != [endpointAddr rangeOfString:@"/"].location)
+            {
+                endpointAddrMatcher = NSLocalizedString(@"CIDR", @"CIDR");
+                endpointInputKind = @(EndpointInputKindCIDR);
+            }
+            else
+            {
+                endpointAddrMatcher = NSLocalizedString(@"IP range", @"IP range");
+                endpointInputKind = @(EndpointInputKindRange);
+            }
         }
         //looks like a CIDR ('/') but didn't parse?
         // reject (rather than silently storing a dead exact-match rule)
@@ -388,6 +478,16 @@ bail:
         {
             //show alert
             showAlert(NSAlertStyleWarning, NSLocalizedString(@"ERROR: invalid CIDR", @"ERROR: invalid CIDR"), [NSString stringWithFormat:NSLocalizedString(@"%@ is not a valid CIDR (e.g. 192.168.1.0/24)", @"%@ is not a valid CIDR (e.g. 192.168.1.0/24)"), endpointAddr], @[NSLocalizedString(@"OK", @"OK")]);
+
+            //bail
+            goto bail;
+        }
+        //looks like an IP range, but didn't parse?
+        // reject obvious range input rather than storing a dead exact-match rule
+        else if(YES == [self looksLikeIPRange:endpointAddr])
+        {
+            //show alert
+            showAlert(NSAlertStyleWarning, NSLocalizedString(@"ERROR: invalid IP range", @"ERROR: invalid IP range"), [NSString stringWithFormat:NSLocalizedString(@"%@ is not a valid IP range (e.g. 1.2.3.4 - 23.3.4.6)", @"%@ is not a valid IP range (e.g. 1.2.3.4 - 23.3.4.6)"), endpointAddr], @[NSLocalizedString(@"OK", @"OK")]);
 
             //bail
             goto bail;
@@ -418,6 +518,10 @@ bail:
     self.info = @{KEY_PATH:path,
                   KEY_ENDPOINT_ADDR:endpointAddr,
                   KEY_ENDPOINT_ADDR_IS_REGEX:endpointAddrRegex,
+                  KEY_ENDPOINT_ADDR_DISPLAY:endpointAddrDisplay,
+                  KEY_ENDPOINT_ADDR_MATCHER:endpointAddrMatcher,
+                  KEY_ENDPOINT_INPUT_KIND:endpointInputKind,
+                  KEY_ENDPOINT_INPUT_NORMALIZED:endpointInputNormalized,
                   KEY_ENDPOINT_PORT:endpointPort,
                   KEY_TYPE:@RULE_TYPE_USER,
                   KEY_ACTION:action};

--- a/LuLu/App/Base.lproj/Rules.xib
+++ b/LuLu/App/Base.lproj/Rules.xib
@@ -106,18 +106,30 @@
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jpF-QT-jfh">
-                                                            <rect key="frame" x="1" y="13" width="753" height="20"/>
+                                                            <rect key="frame" x="1" y="20" width="753" height="20"/>
                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" title="connection info" id="tZf-9e-yHh">
                                                                 <font key="font" size="17" name="Menlo-Regular"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                         </textField>
+                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="101" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XnP-mA-rg9">
+                                                            <rect key="frame" x="1" y="5" width="753" height="13"/>
+                                                            <textFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" title="" id="P28-Qc-fKh">
+                                                                <font key="font" size="11" name="Menlo-Regular"/>
+                                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
                                                     </subviews>
                                                     <constraints>
+                                                        <constraint firstAttribute="bottom" secondItem="XnP-mA-rg9" secondAttribute="bottom" constant="5" id="8eu-fg-i0X"/>
+                                                        <constraint firstItem="XnP-mA-rg9" firstAttribute="top" secondItem="jpF-QT-jfh" secondAttribute="bottom" constant="2" id="Edd-jf-kmb"/>
                                                         <constraint firstAttribute="trailing" secondItem="jpF-QT-jfh" secondAttribute="trailing" constant="3" id="Mf6-7V-C48"/>
+                                                        <constraint firstAttribute="trailing" secondItem="XnP-mA-rg9" secondAttribute="trailing" constant="3" id="ZqH-oZ-frd"/>
                                                         <constraint firstItem="jpF-QT-jfh" firstAttribute="leading" secondItem="Tec-Zl-6cm" secondAttribute="leading" constant="3" id="emp-cE-Z8y"/>
-                                                        <constraint firstItem="jpF-QT-jfh" firstAttribute="top" secondItem="Tec-Zl-6cm" secondAttribute="top" constant="17" id="opg-Gi-wb1"/>
+                                                        <constraint firstItem="XnP-mA-rg9" firstAttribute="leading" secondItem="Tec-Zl-6cm" secondAttribute="leading" constant="3" id="jPN-S8-1IC"/>
+                                                        <constraint firstItem="jpF-QT-jfh" firstAttribute="top" secondItem="Tec-Zl-6cm" secondAttribute="top" constant="10" id="opg-Gi-wb1"/>
                                                     </constraints>
                                                     <connections>
                                                         <outlet property="textField" destination="jpF-QT-jfh" id="NNr-pk-0TP"/>

--- a/LuLu/App/RulesWindowController.m
+++ b/LuLu/App/RulesWindowController.m
@@ -1287,8 +1287,8 @@ bail:
     //endpoint addr
     NSString* address = nil;
     
-    //item cell
-    //NSTableCellView* cell = nil;
+    //matcher details
+    NSString* matcher = nil;
     
     //contents
     NSMutableString* contents = nil;
@@ -1299,31 +1299,43 @@ bail:
     //date formatter
     static NSDateFormatter *dateFormatter = nil;
     
+    //detail text field
+    NSTextField* details = nil;
+    
     //cell
     CustomTableCellView *cell = (CustomTableCellView *)[self.outlineView makeViewWithIdentifier:@"simpleCell" owner:self];
+    
+    //grab details
+    details = (NSTextField*)[cell viewWithTag:TABLE_ROW_SUB_TEXT];
     
     //disabled?
     // set flag (for highlighting) and color
     cell.isDisabled = rule.isDisabled.boolValue;
     if (rule.isDisabled.boolValue) {
         cell.textField.textColor = NSColor.disabledControlTextColor;
+        details.textColor = NSColor.disabledControlTextColor;
     } else {
         cell.textField.textColor = NSColor.controlTextColor;
+        details.textColor = NSColor.secondaryLabelColor;
     }
     
     //reset text
     ((NSTableCellView*)cell).textField.stringValue = @"";
     ((NSTableCellView*)cell).textField.attributedStringValue = [[NSAttributedString alloc] initWithString:@""];
+    details.stringValue = @"";
     
     //set endpoint addr
-    address = (YES == [rule.endpointAddr isEqualToString:VALUE_ANY]) ? NSLocalizedString(@"any address",@"any address") : rule.endpointAddr;
+    address = (YES == [[rule friendlyEndpointAddr] isEqualToString:VALUE_ANY]) ? NSLocalizedString(@"any address",@"any address") : [rule friendlyEndpointAddr];
     
     //set endpoint port
     port = (YES == [rule.endpointPort isEqualToString:VALUE_ANY]) ? NSLocalizedString(@"any port",@"any port") : rule.endpointPort;
     
     //default contents
-    // address: port
-    contents = [NSMutableString stringWithFormat:@"%@:%@", address, port];
+    // type | address: port
+    contents = [NSMutableString stringWithFormat:@"%@ | %@:%@", [rule friendlyEndpointType], address, port];
+    
+    //matcher details
+    matcher = [NSString stringWithFormat:NSLocalizedString(@"Matcher: %@", @"Matcher: %@"), [rule friendlyEndpointMatcher]];
     
     //in "recents" view, add creation timestamp
     if(RULE_TYPE_RECENT == self.selectedRuleView)
@@ -1343,6 +1355,11 @@ bail:
 
     //set text
     cell.textField.stringValue = contents;
+    cell.textField.toolTip = contents;
+    
+    //set detail text
+    details.stringValue = matcher;
+    details.toolTip = matcher;
     
     return cell;
 }

--- a/LuLu/Shared/Localizable.xcstrings
+++ b/LuLu/Shared/Localizable.xcstrings
@@ -1479,6 +1479,9 @@
     "%@ is not a valid CIDR (e.g. 192.168.1.0/24)" : {
       "comment" : "%@ is not a valid CIDR (e.g. 192.168.1.0/24)"
     },
+    "%@ is not a valid IP range (e.g. 1.2.3.4 - 23.3.4.6)" : {
+      "comment" : "%@ is not a valid IP range (e.g. 1.2.3.4 - 23.3.4.6)"
+    },
     "%@ is not a valid regular expression\r\ndetails: %@" : {
       "comment" : "%@ is not a valid regular expression\r\ndetails: %@",
       "localizations" : {
@@ -3719,6 +3722,9 @@
         }
       }
     },
+    "CIDR" : {
+      "comment" : "CIDR"
+    },
     "Clean up rules referencing deleted, expired, or terminated items?" : {
       "comment" : "Clean up rules referencing deleted, expired, or terminated items?",
       "localizations" : {
@@ -5729,6 +5735,9 @@
     "ERROR: invalid CIDR" : {
       "comment" : "ERROR: invalid CIDR"
     },
+    "ERROR: invalid IP range" : {
+      "comment" : "ERROR: invalid IP range"
+    },
     "ERROR: invalid path" : {
       "comment" : "ERROR: invalid path",
       "localizations" : {
@@ -6036,6 +6045,9 @@
           }
         }
       }
+    },
+    "Exact" : {
+      "comment" : "Exact"
     },
     "Extensions must be manually approved via System Settings (General > Login Items & Extensions > Network Extensions)." : {
       "comment" : "Extensions must be manually approved via System Settings (General > Login Items & Extensions > Network Extensions).",
@@ -6499,6 +6511,9 @@
         }
       }
     },
+    "Generated regex: %@" : {
+      "comment" : "Generated regex: %@"
+    },
     "Global Rules apply to all paths" : {
       "comment" : "Global Rules apply to all paths",
       "localizations" : {
@@ -6806,6 +6821,12 @@
           }
         }
       }
+    },
+    "IP range" : {
+      "comment" : "IP range"
+    },
+    "IP Range" : {
+      "comment" : "IP Range"
     },
     "is connecting to %@" : {
       "comment" : "is connecting to %@",
@@ -7209,6 +7230,9 @@
           }
         }
       }
+    },
+    "Matcher: %@" : {
+      "comment" : "Matcher: %@"
     },
     "More Info" : {
       "comment" : "More Info",
@@ -9056,6 +9080,12 @@
         }
       }
     },
+    "Regex" : {
+      "comment" : "Regex"
+    },
+    "Regex: %@" : {
+      "comment" : "Regex: %@"
+    },
     "Reverse Domain: %@" : {
       "comment" : "Reverse Domain %@",
       "localizations" : {
@@ -10175,6 +10205,9 @@
           }
         }
       }
+    },
+    "Wildcard" : {
+      "comment" : "Wildcard"
     }
   },
   "version" : "1.0"

--- a/LuLu/Shared/Rule.h
+++ b/LuLu/Shared/Rule.h
@@ -59,6 +59,18 @@
 //remote ip or url
 @property(nonatomic, retain)NSString* endpointAddr;
 
+//user-friendly endpoint display metadata
+@property(nonatomic, retain)NSString* endpointAddrDisplay;
+
+//technical endpoint matcher display metadata
+@property(nonatomic, retain)NSString* endpointAddrMatcher;
+
+//original endpoint input kind
+@property(nonatomic, retain)NSNumber* endpointInputKind;
+
+//normalized original endpoint input
+@property(nonatomic, retain)NSString* endpointInputNormalized;
+
 //remote host
 @property(nonatomic, retain)NSString* endpointHost;
 
@@ -126,6 +138,15 @@
 
 //check if a numeric IP string falls within this rule's (cached) CIDR/range endpoint
 -(BOOL)endpointAddrInRange:(NSString*)address;
+
+//friendly endpoint display value
+-(NSString*)friendlyEndpointAddr;
+
+//technical matcher display value
+-(NSString*)friendlyEndpointMatcher;
+
+//friendly endpoint type label
+-(NSString*)friendlyEndpointType;
 
 //covert to dictionary
 -(NSMutableString*)toJSON;

--- a/LuLu/Shared/Rule.m
+++ b/LuLu/Shared/Rule.m
@@ -86,6 +86,12 @@ extern os_log_t logHandle;
             //endpoint addr match type {exact, regex, cidr}
             self.isEndpointAddrRegex = [info[KEY_ENDPOINT_ADDR_IS_REGEX] integerValue];
             
+            //friendly display metadata
+            self.endpointAddrDisplay = info[KEY_ENDPOINT_ADDR_DISPLAY];
+            self.endpointAddrMatcher = info[KEY_ENDPOINT_ADDR_MATCHER];
+            self.endpointInputKind = info[KEY_ENDPOINT_INPUT_KIND];
+            self.endpointInputNormalized = info[KEY_ENDPOINT_INPUT_NORMALIZED];
+            
             //init port
             // nil? default to all ('*')
             self.endpointPort = (nil != info[KEY_ENDPOINT_PORT]) ? info[KEY_ENDPOINT_PORT] : VALUE_ANY;
@@ -295,6 +301,10 @@ extern os_log_t logHandle;
         // note: legacy archives stored a bool here (0/1); decodeInteger reads those cleanly
         self.isEndpointAddrRegex = [decoder decodeIntegerForKey:NSStringFromSelector(@selector(isEndpointAddrRegex))];
         self.endpointAddr = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(endpointAddr))];
+        self.endpointAddrDisplay = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(endpointAddrDisplay))];
+        self.endpointAddrMatcher = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(endpointAddrMatcher))];
+        self.endpointInputKind = [decoder decodeObjectOfClass:[NSNumber class] forKey:NSStringFromSelector(@selector(endpointInputKind))];
+        self.endpointInputNormalized = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(endpointInputNormalized))];
         self.endpointHost = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(endpointHost))];
         self.endpointPort = [decoder decodeObjectOfClass:[NSString class] forKey:NSStringFromSelector(@selector(endpointPort))];
         
@@ -325,6 +335,10 @@ extern os_log_t logHandle;
     [encoder encodeObject:self.csInfo forKey:NSStringFromSelector(@selector(csInfo))];
     
     [encoder encodeObject:self.endpointAddr forKey:NSStringFromSelector(@selector(endpointAddr))];
+    [encoder encodeObject:self.endpointAddrDisplay forKey:NSStringFromSelector(@selector(endpointAddrDisplay))];
+    [encoder encodeObject:self.endpointAddrMatcher forKey:NSStringFromSelector(@selector(endpointAddrMatcher))];
+    [encoder encodeObject:self.endpointInputKind forKey:NSStringFromSelector(@selector(endpointInputKind))];
+    [encoder encodeObject:self.endpointInputNormalized forKey:NSStringFromSelector(@selector(endpointInputNormalized))];
     [encoder encodeObject:self.endpointHost forKey:NSStringFromSelector(@selector(endpointHost))];
     [encoder encodeObject:self.endpointPort forKey:NSStringFromSelector(@selector(endpointPort))];
     [encoder encodeInteger:self.isEndpointAddrRegex forKey:NSStringFromSelector(@selector(isEndpointAddrRegex))];
@@ -391,6 +405,9 @@ extern os_log_t logHandle;
     
     //endpoint addr/port
     if( (YES == [self.endpointAddr localizedCaseInsensitiveContainsString:match]) ||
+        (YES == [self.endpointAddrDisplay localizedCaseInsensitiveContainsString:match]) ||
+        (YES == [self.endpointAddrMatcher localizedCaseInsensitiveContainsString:match]) ||
+        (YES == [[self friendlyEndpointType] localizedCaseInsensitiveContainsString:match]) ||
         (YES == [self.endpointPort localizedCaseInsensitiveContainsString:match]) )
     {
         //match
@@ -436,6 +453,72 @@ bail:
     return [self.uuid isEqualToString:rule.uuid];
 }
 
+//friendly endpoint display value
+-(NSString*)friendlyEndpointAddr
+{
+    if(0 != self.endpointAddrDisplay.length) {
+        return self.endpointAddrDisplay;
+    }
+    
+    return (nil != self.endpointAddr) ? self.endpointAddr : VALUE_ANY;
+}
+
+//technical matcher display value
+-(NSString*)friendlyEndpointMatcher
+{
+    if(0 != self.endpointAddrMatcher.length) {
+        return self.endpointAddrMatcher;
+    }
+    
+    if(EndpointTypeRegex == self.isEndpointAddrRegex) {
+        return [NSString stringWithFormat:NSLocalizedString(@"Regex: %@", @"Regex: %@"), self.endpointAddr];
+    }
+    
+    if(EndpointTypeCIDR == self.isEndpointAddrRegex) {
+        return (NSNotFound != [self.endpointAddr rangeOfString:@"/"].location) ? NSLocalizedString(@"CIDR", @"CIDR") : NSLocalizedString(@"IP range", @"IP range");
+    }
+    
+    return NSLocalizedString(@"Exact", @"Exact");
+}
+
+//friendly endpoint type label
+-(NSString*)friendlyEndpointType
+{
+    if(nil != self.endpointInputKind)
+    {
+        switch(self.endpointInputKind.integerValue)
+        {
+            case EndpointInputKindRegex:
+                return NSLocalizedString(@"Regex", @"Regex");
+                
+            case EndpointInputKindCIDR:
+                return NSLocalizedString(@"CIDR", @"CIDR");
+                
+            case EndpointInputKindRange:
+                return NSLocalizedString(@"IP Range", @"IP Range");
+                
+            case EndpointInputKindGlob:
+                return NSLocalizedString(@"Wildcard", @"Wildcard");
+                
+            case EndpointInputKindExact:
+                return NSLocalizedString(@"Exact", @"Exact");
+                
+            default:
+                break;
+        }
+    }
+    
+    if(EndpointTypeRegex == self.isEndpointAddrRegex) {
+        return NSLocalizedString(@"Regex", @"Regex");
+    }
+    
+    if(EndpointTypeCIDR == self.isEndpointAddrRegex) {
+        return (NSNotFound != [self.endpointAddr rangeOfString:@"/"].location) ? NSLocalizedString(@"CIDR", @"CIDR") : NSLocalizedString(@"IP Range", @"IP Range");
+    }
+    
+    return NSLocalizedString(@"Exact", @"Exact");
+}
+
 //override description method
 // allows rules to be 'pretty-printed'
 -(NSString*)description
@@ -462,7 +545,7 @@ bail:
     }
     
     //just serialize
-    return [NSString stringWithFormat:@"RULE: pid: %@, path: %@, name: %@, endpoint addr: %@, endpoint port: %@, action: %@, type: %@, disabled: %@, creation: %@, expiration: %@", pid, self.path, self.name, self.endpointAddr, self.endpointPort, self.action, self.type, isDisabled, self.creation, expiration];
+    return [NSString stringWithFormat:@"RULE: pid: %@, path: %@, name: %@, endpoint addr: %@, endpoint display: %@, endpoint matcher: %@, endpoint port: %@, action: %@, type: %@, disabled: %@, creation: %@, expiration: %@", pid, self.path, self.name, self.endpointAddr, self.endpointAddrDisplay, self.endpointAddrMatcher, self.endpointPort, self.action, self.type, isDisabled, self.creation, expiration];
 }
 
 //covert rule to dictionary
@@ -511,6 +594,29 @@ bail:
     if(nil != escaped)
     {
         [json appendFormat:@"\"%@\" : %@,", NSStringFromSelector(@selector(endpointAddr)), escaped];
+    }
+    
+    escaped = toEscapedJSON(self.endpointAddrDisplay);
+    if(nil != escaped)
+    {
+        [json appendFormat:@"\"%@\" : %@,", NSStringFromSelector(@selector(endpointAddrDisplay)), escaped];
+    }
+    
+    escaped = toEscapedJSON(self.endpointAddrMatcher);
+    if(nil != escaped)
+    {
+        [json appendFormat:@"\"%@\" : %@,", NSStringFromSelector(@selector(endpointAddrMatcher)), escaped];
+    }
+    
+    if(nil != self.endpointInputKind)
+    {
+        [json appendFormat:@"\"%@\" : %d,", NSStringFromSelector(@selector(endpointInputKind)), self.endpointInputKind.intValue];
+    }
+    
+    escaped = toEscapedJSON(self.endpointInputNormalized);
+    if(nil != escaped)
+    {
+        [json appendFormat:@"\"%@\" : %@,", NSStringFromSelector(@selector(endpointInputNormalized)), escaped];
     }
     
     if(nil != self.endpointHost)
@@ -719,6 +825,54 @@ bail:
         {
             //err msg
             os_log_error(logHandle, "ERROR: 'endpointAddr' should be a string, not %@", [self.endpointAddr class]);
+            
+            self = nil;
+            goto bail;
+        }
+        
+        self.endpointAddrDisplay = info[NSStringFromSelector(@selector(endpointAddrDisplay))];
+        if( (nil != self.endpointAddrDisplay) &&
+            (YES != [self.endpointAddrDisplay isKindOfClass:[NSString class]]) )
+        {
+            //err msg
+            os_log_error(logHandle, "ERROR: 'endpointAddrDisplay' should be a string, not %@", [self.endpointAddrDisplay class]);
+            
+            self = nil;
+            goto bail;
+        }
+        
+        self.endpointAddrMatcher = info[NSStringFromSelector(@selector(endpointAddrMatcher))];
+        if( (nil != self.endpointAddrMatcher) &&
+            (YES != [self.endpointAddrMatcher isKindOfClass:[NSString class]]) )
+        {
+            //err msg
+            os_log_error(logHandle, "ERROR: 'endpointAddrMatcher' should be a string, not %@", [self.endpointAddrMatcher class]);
+            
+            self = nil;
+            goto bail;
+        }
+        
+        self.endpointInputKind = info[NSStringFromSelector(@selector(endpointInputKind))];
+        if([self.endpointInputKind isKindOfClass:[NSString class]]) {
+            self.endpointInputKind = @([(NSString*)self.endpointInputKind integerValue]);
+        }
+        
+        if( (nil != self.endpointInputKind) &&
+            (YES != [self.endpointInputKind isKindOfClass:[NSNumber class]]) )
+        {
+            //err msg
+            os_log_error(logHandle, "ERROR: 'endpointInputKind' should be a number, not %@", [self.endpointInputKind class]);
+            
+            self = nil;
+            goto bail;
+        }
+        
+        self.endpointInputNormalized = info[NSStringFromSelector(@selector(endpointInputNormalized))];
+        if( (nil != self.endpointInputNormalized) &&
+            (YES != [self.endpointInputNormalized isKindOfClass:[NSString class]]) )
+        {
+            //err msg
+            os_log_error(logHandle, "ERROR: 'endpointInputNormalized' should be a string, not %@", [self.endpointInputNormalized class]);
             
             self = nil;
             goto bail;

--- a/LuLu/Shared/consts.h
+++ b/LuLu/Shared/consts.h
@@ -31,6 +31,17 @@ typedef NS_ENUM(NSInteger, EndpointType) {
     EndpointTypeCIDR  = 2,
 };
 
+//endpoint input kind
+// used only for display/import-export metadata; matching still uses EndpointType
+typedef NS_ENUM(NSInteger, EndpointInputKind) {
+    EndpointInputKindExact = 0,
+    EndpointInputKindRegex = 1,
+    EndpointInputKindCIDR = 2,
+    EndpointInputKindRange = 3,
+    EndpointInputKindGlob = 4,
+    EndpointInputKindUnknown = 99,
+};
+
 //patreon url
 #define PATREON_URL @"https://www.patreon.com/join/objective_see"
 
@@ -338,6 +349,10 @@ typedef NS_ENUM(NSInteger, EndpointType) {
 #define KEY_ENDPOINT_PORT @"endpointPort"
 
 #define KEY_ENDPOINT_ADDR_IS_REGEX @"endpointAddrIsRegex"
+#define KEY_ENDPOINT_ADDR_DISPLAY @"endpointAddrDisplay"
+#define KEY_ENDPOINT_ADDR_MATCHER @"endpointAddrMatcher"
+#define KEY_ENDPOINT_INPUT_KIND @"endpointInputKind"
+#define KEY_ENDPOINT_INPUT_NORMALIZED @"endpointInputNormalized"
 
 #define KEY_UUID @"uuid"
 #define KEY_PROCESS_ID @"pid"

--- a/LuLu/Shared/utilities.h
+++ b/LuLu/Shared/utilities.h
@@ -135,4 +135,7 @@ BOOL addressInRange(NSString* address, int family, const uint8_t* lo, const uint
 //is a string a valid CIDR or IP range?
 BOOL isAddressRange(NSString* spec);
 
+//does a string look like an intended IP range?
+BOOL looksLikeIPAddressRange(NSString* input);
+
 #endif

--- a/LuLu/Shared/utilities.m
+++ b/LuLu/Shared/utilities.m
@@ -1983,6 +1983,60 @@ BOOL addressInRange(NSString* address, int family, const uint8_t* lo, const uint
     return ((memcmp(lo, ip, length) <= 0) && (memcmp(ip, hi, length) <= 0));
 }
 
+//is a string an IP address literal?
+BOOL isIPAddressLiteral(NSString* input)
+{
+    //address bytes
+    uint8_t address[16] = {0};
+    
+    //empty?
+    if(0 == input.length) {
+        return NO;
+    }
+    
+    //IPv4/IPv6?
+    return ( (1 == inet_pton(AF_INET, input.UTF8String, address)) ||
+             (1 == inet_pton(AF_INET6, input.UTF8String, address)) );
+}
+
+//does a string look like an intended IP range?
+BOOL looksLikeIPAddressRange(NSString* input)
+{
+    //dash
+    NSRange dash = {0};
+    
+    //sides
+    NSString* left = nil;
+    NSString* right = nil;
+    
+    //whitespace
+    NSCharacterSet* whitespace = nil;
+    
+    //no dash?
+    dash = [input rangeOfString:@"-"];
+    if(NSNotFound == dash.location) {
+        return NO;
+    }
+    
+    //init
+    whitespace = NSCharacterSet.whitespaceCharacterSet;
+    
+    //split
+    left = [[input substringToIndex:dash.location] stringByTrimmingCharactersInSet:whitespace];
+    right = [[input substringFromIndex:(dash.location + 1)] stringByTrimmingCharactersInSet:whitespace];
+    
+    //empty side?
+    if( (0 == left.length) ||
+        (0 == right.length) )
+    {
+        return NO;
+    }
+    
+    //range-like if either side is already a valid IP literal
+    return ( (YES == isIPAddressLiteral(left)) ||
+             (YES == isIPAddressLiteral(right)) );
+}
+
 //is a string a valid CIDR or IP range?
 // note: a plain single IP ("1.2.3.4", "2001:db8::1") returns NO by design
 //       — those are handled as exact-match rules, not ranges

--- a/LuLu/Shared/utilities.m
+++ b/LuLu/Shared/utilities.m
@@ -1946,18 +1946,12 @@ BOOL parseAddressRange(NSString* spec, int* family, uint8_t* lo, uint8_t* hi, in
         else if((1 == inet_pton(AF_INET6, aStr.UTF8String, a)) && (1 == inet_pton(AF_INET6, bStr.UTF8String, b))) { fam = AF_INET6; len = 16; }
         else goto bail;
 
-        //order lo <= hi
+        //require lo <= hi
         // note: network byte order is big-endian, so memcmp gives correct numeric ordering
-        if(memcmp(a, b, len) <= 0)
-        {
-            memcpy(lo, a, len);
-            memcpy(hi, b, len);
-        }
-        else
-        {
-            memcpy(lo, b, len);
-            memcpy(hi, a, len);
-        }
+        if(memcmp(a, b, len) > 0) goto bail;
+        
+        memcpy(lo, a, len);
+        memcpy(hi, b, len);
 
         //done
         *family = fam;


### PR DESCRIPTION
## Motivation
User-entered IP range such as: 1.2.3.4 - 23.3.4.6 should remain recognizable as an IP range rule in the UI.
The goal is to make range, CIDR, and wildcard rules easier to understand and manage while preserving compatibility with existing rules and matcher semantics.

## Changes
• Added optional endpoint display metadata to Rule.
• Added archive and JSON import/export support for the new optional metadata.
• Added friendly endpoint helper methods for display/type/matcher text.
• Updated Add/Edit Rule behavior to preserve the user-friendly endpoint input.
• Preserved generated wildcard regex as the technical matcher while showing the original wildcard value.
• Updated the rules list connection row to show matcher details in a dedicated detail line.
• Added tooltips for long endpoint and matcher text.
• Rejected reversed IP ranges instead of silently normalizing them.
• Rejected malformed IP range-like input instead of saving it as an exact-match rule.

## Related issue

Closes #885 
