### PR TITLE
fix: release paused flows when alert delivery fails

### DIFF
--- a/LuLu/Extension/FilterDataProvider.m
+++ b/LuLu/Extension/FilterDataProvider.m
@@ -930,25 +930,35 @@ bail:
 
     //deliver alert
     // and process user response
-    if(YES != [alerts deliver:alert reply:^(NSDictionary* alert)
+    if(YES != [alerts deliver:alert reply:^(NSDictionary* userReply)
     {
         //re-strengthen to avoid races within the block
         __strong typeof(weakSelf) strongSelf = weakSelf;
         __strong NEFilterSocketFlow* strongFlow = weakFlow;
 
+        //delivery failed after the flow was already paused
+        // release this process' held flows so NetworkExtension doesn't retain them indefinitely
+        if(nil == userReply)
+        {
+            os_log_error(logHandle, "ERROR: alert delivery failed after pausing flow for %{public}@; releasing held flows", alert[KEY_PATH]);
+            [alerts removeShown:alert[KEY_KEY]];
+            [strongSelf resumeFlowsForKey:alert[KEY_KEY] verdict:[NEFilterNewFlowVerdict allowVerdict]];
+            return;
+        }
+
         //log msg
         // note, this msg persists in log
-        os_log(logHandle, "(user) response: \"%@\" for %{public}@, that was trying to connect to %{public}@:%{public}@", (RULE_STATE_BLOCK == [alert[KEY_ACTION] unsignedIntValue]) ? @"block" : @"allow", alert[KEY_PATH], alert[KEY_ENDPOINT_ADDR], alert[KEY_ENDPOINT_PORT]);
+        os_log(logHandle, "(user) response: \"%@\" for %{public}@, that was trying to connect to %{public}@:%{public}@", (RULE_STATE_BLOCK == [userReply[KEY_ACTION] unsignedIntValue]) ? @"block" : @"allow", userReply[KEY_PATH], userReply[KEY_ENDPOINT_ADDR], userReply[KEY_ENDPOINT_PORT]);
 
         //'once'? no rule created
         // apply the user's verdict to just this (alerted) flow; the next flow will re-prompt
-        if(RuleDurationOnce == [alert[KEY_DURATION] intValue])
+        if(RuleDurationOnce == [userReply[KEY_DURATION] intValue])
         {
             //dbg msg
             os_log_debug(logHandle, "'once' response, so just handling here ...no rule will be created");
             
             //verdict from user's action
-            NEFilterNewFlowVerdict* verdict = (RULE_STATE_BLOCK == [alert[KEY_ACTION] unsignedIntValue])
+            NEFilterNewFlowVerdict* verdict = (RULE_STATE_BLOCK == [userReply[KEY_ACTION] unsignedIntValue])
                 ? [NEFilterNewFlowVerdict dropVerdict]
                 : [NEFilterNewFlowVerdict allowVerdict];
 
@@ -960,7 +970,7 @@ bail:
         else
         {
             //init rule
-            rule = [[Rule alloc] init:alert];
+            rule = [[Rule alloc] init:userReply];
 
             //add / save
             [rules add:rule save:![rule isTemporary]];

--- a/LuLu/Extension/XPCUserClient.m
+++ b/LuLu/Extension/XPCUserClient.m
@@ -28,7 +28,11 @@ extern os_log_t logHandle;
 {
     //flag
     __block BOOL xpcError = NO;
-    
+
+    //ensure reply path fires at most once
+    NSObject* callbackGuard = [NSObject new];
+    __block BOOL callbackDelivered = NO;
+
     //sanity check
     // no client connection?
     if(nil == xpcListener.client)
@@ -56,13 +60,31 @@ extern os_log_t logHandle;
             //set error
             xpcError = YES;
             
+            //if the proxy fails after the caller already paused the flow,
+            // notify it so it can release any held flow state
+            @synchronized(callbackGuard)
+            {
+                if(YES != callbackDelivered)
+                {
+                    callbackDelivered = YES;
+                    reply(nil);
+                }
+            }
+
         }] alertShow:alert reply:^(NSDictionary* userReply)
         {
             //dbg msg
             os_log_debug(logHandle, "reply: %{public}@", alert);
             
             //respond
-            reply(userReply);
+            @synchronized(callbackGuard)
+            {
+                if(YES != callbackDelivered)
+                {
+                    callbackDelivered = YES;
+                    reply(userReply);
+                }
+            }
         }];
     }
 


### PR DESCRIPTION
## Summary
This addresses one likely paused-flow retention path behind #873.

## Root Cause
`deliverAlert:reply:` returns success immediately after sending the async XPC request. If that proxy fails afterward, the caller has already treated the alert as delivered, stored it in `shownAlerts`, and kept the flow paused. Because no reply callback fires on that path, the paused flow can remain held indefinitely.

## Fix
- route post-send XPC proxy failures back through the reply callback
- make the callback single-shot so success/error cannot both run cleanup
- on a `nil` reply, remove the shown alert entry and resume held flows for that process key

## Validation
- syntax-checked the touched Objective-C files
- ran `LuLu/Tests/run_passive_mode_tests.sh` successfully (9/9)
- exercised a local harness for the async failure path to confirm single-shot callback + paused-flow cleanup

## Scope
This addresses one likely retention path from #873. I have not confirmed end-to-end that it resolves every memory-growth report behind the issue.

Fixes #873